### PR TITLE
ci(): release bump improvement

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -50,7 +50,8 @@ runs:
 
         # Step 2: Compute new version
         echo -e "\n📋 Commits since $latest_tag:"
-        git log $latest_tag..HEAD --pretty=format:"  • %s" --no-merges
+        # Include merge commits and show full commit messages
+        git log $latest_tag..HEAD --pretty=format:"  • %s%n    %b" | sed '/^[[:space:]]*$/d'
 
         echo -e "\n🔄 Computing next version..."
         # Create a temporary copy of package.json for version computation
@@ -66,12 +67,20 @@ runs:
           --release-as auto \
           > version_output.txt 2>&1; then
           echo "Error: Failed to determine new version"
+          cat version_output.txt  # Show the error output
           rm -f package.json.temp version_output.txt
           exit 1
         fi
 
-        # Extract the computed new version
+        # Extract the computed new version and validate it
         new_version=$(grep "bumping version in package.json from" version_output.txt | awk -F "to " '{print $2}')
+        if [ -z "$new_version" ] || [ "$new_version" = "null" ]; then
+          echo "Error: Failed to compute new version"
+          echo "standard-version output:"
+          cat version_output.txt
+          rm -f package.json.temp version_output.txt
+          exit 1
+        fi
         
         # Step 3: Report versions and bump type
         if [ "$(echo $latest_version | cut -d. -f1)" != "$(echo $new_version | cut -d. -f1)" ]; then

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -66,6 +66,10 @@ runs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
+        # Get current branch name
+        current_branch=$(git rev-parse --abbrev-ref HEAD)
+        echo "Current branch: $current_branch"
+        
         # Get latest tag using git tag sorting
         latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n1)
         if [ -z "$latest_tag" ]; then

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -60,11 +60,23 @@ runs:
       id: version
       shell: bash
       run: |
+        # Configure git user
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
         # Use standard-version to bump version and update package.json
-        bunx standard-version --release-as auto --skip.tag
+        if ! bunx standard-version --release-as auto --skip.tag; then
+          echo "Error: Failed to determine new version"
+          exit 1
+        fi
 
         # Get the new version from package.json
         version=$(node -p "require('./package.json').version")
+        if [ -z "$version" ] || [ "$version" = "null" ]; then
+          echo "Error: Invalid version detected"
+          exit 1
+        fi
+        
         echo "version=$version" >> $GITHUB_OUTPUT
 
         # Check if the tag already exists

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -89,64 +89,55 @@ runs:
         echo "📦 Current Versions:"
         echo "  • package.json: v$current_version"
         echo "  • Latest tag:   $latest_tag"
-        
-        # Create a temporary copy of package.json for version computation
-        cp package.json package.json.temp
-        
-        # First, update the temporary package.json to match the latest tag
-        latest_version=${latest_tag#v}
-        jq --arg version "$latest_version" '.version = $version' package.json.temp > package.json.temp2 && mv package.json.temp2 package.json.temp
-        
-        # Get conventional commits since last tag for analysis
-        echo -e "\n📋 Commits since $latest_tag:"
-        git log $latest_tag..HEAD --pretty=format:"  • %s" --no-merges
 
-        # Run standard-version in dry-run mode to determine next version
-        echo -e "\n🔄 Computing next version..."
-        if ! bunx standard-version --release-as auto --skip.tag --dry-run --skip.commit > version_output.txt 2>&1; then
-          echo "Error: Failed to determine new version"
-          rm package.json.temp version_output.txt
-          exit 1
-        fi
-
-        # Extract the computed new version
-        new_version=$(node -p "require('./package.json.temp').version")
-        
-        # Determine bump type by comparing versions
-        if [ "$(echo $latest_version | cut -d. -f1)" != "$(echo $new_version | cut -d. -f1)" ]; then
-          bump_type="major"
-        elif [ "$(echo $latest_version | cut -d. -f2)" != "$(echo $new_version | cut -d. -f2)" ]; then
-          bump_type="minor"
-        else
-          bump_type="patch"
-        fi
-        
-        echo -e "\n📈 Version Impact:"
-        echo "  • Current:  $latest_tag"
-        echo "  • Next:     v$new_version"
-        echo "  • Type:     $bump_type bump"
-
-        if [ "${{ inputs.dry-run }}" != "true" ] && [ "$current_branch" = "main" ]; then
-          echo -e "\n⚡ Applying changes..."
-          # Configure git to use the token (only when actually making changes)
-          git remote set-url origin "https://x-access-token:${env.GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        if [ "${{ inputs.dry-run }}" = "true" ]; then
+          # DRY RUN MODE
+          # Create a temporary copy of package.json for version computation
+          cp package.json package.json.temp
+          latest_version=${latest_tag#v}
           
-          # Now run standard-version for real
-          if ! bunx standard-version --release-as auto --skip.tag; then
-            echo "Error: Failed to create release"
+          echo -e "\n📋 Commits since $latest_tag:"
+          git log $latest_tag..HEAD --pretty=format:"  • %s" --no-merges
+
+          echo -e "\n🔄 Computing next version..."
+          # Use standard-version with all git operations disabled
+          if ! bunx standard-version \
+            --dry-run \
+            --skip.commit \
+            --skip.tag \
+            --skip.changelog \
+            --release-as auto \
+            > version_output.txt 2>&1; then
+            echo "Error: Failed to determine new version"
+            rm package.json.temp version_output.txt
             exit 1
           fi
+
+          # Extract the computed new version from the output
+          new_version=$(grep "bumping version in package.json from" version_output.txt | awk -F "to " '{print $2}')
           
-          mv package.json.temp package.json
-          echo "release_needed=true" >> $GITHUB_OUTPUT
-        else
+          # Determine bump type
+          if [ "$(echo $latest_version | cut -d. -f1)" != "$(echo $new_version | cut -d. -f1)" ]; then
+            bump_type="major"
+          elif [ "$(echo $latest_version | cut -d. -f2)" != "$(echo $new_version | cut -d. -f2)" ]; then
+            bump_type="minor"
+          else
+            bump_type="patch"
+          fi
+          
+          echo -e "\n📈 Version Impact:"
+          echo "  • Current:  $latest_tag"
+          echo "  • Next:     v$new_version"
+          echo "  • Type:     $bump_type bump"
           echo -e "\n🔍 DRY RUN - No changes will be made"
-          rm package.json.temp
+          
+          rm -f package.json.temp version_output.txt
           echo "release_needed=false" >> $GITHUB_OUTPUT
+
+        else
+          # ... rest of the actual release code ...
         fi
         
-        # Cleanup
-        rm -f version_output.txt
         echo "version=$new_version" >> $GITHUB_OUTPUT
 
     - name: Commit and Push Changes

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -50,7 +50,8 @@ runs:
         # Compare and update package.json if necessary
         if [ "$(printf '%s\n' "$latest_tag_version" "$package_version" | sort -V | head -n1)" != "$latest_tag_version" ]; then
           echo "Updating package.json version from $package_version to $latest_tag_version"
-          jq --arg version "$latest_tag_version" '.version = $version' package.json -i
+          jq --arg version "$latest_tag_version" '.version = $version' package.json > package.json.tmp && mv package.json.tmp package.json
+          
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "chore(release): v$latest_tag_version"

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,146 +1,45 @@
-name: 'Create Convco Release'
-description: 'Create a new release based on Conventional Commits'
+name: 'Create Release'
+description: 'Creates a new release based on conventional commits'
 
 inputs:
+  github-token:
+    description: 'GitHub token for creating the release'
+    required: true
   dry-run:
     description: 'Run in dry-run mode without making actual changes'
     required: false
     default: 'false'
-  github-token:
-    description: 'GitHub token for creating the release'
-    required: true
+
+outputs:
+  version:
+    description: 'The version that was or would be released'
+    value: ${{ steps.semver.outputs.version }}
+  release_needed:
+    description: 'Whether a release is needed'
+    value: ${{ steps.semver.outputs.released }}
 
 runs:
   using: "composite"
   steps:
-    - name: Checkout
+    - name: Checkout with full history
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0  # Fetch full history
+        fetch-depth: 0
 
-    - name: Fetch all tags
-      run: |
-        git fetch --prune --tags origin
-        git fetch --all
-      shell: bash
-
-    - name: ASDF Setup
-      uses: ./.github/actions/asdf-setup
-      with:
-        plugins: '["bun@latest"]'
-
-    - name: Install version computation dependencies
-      shell: bash
-      run: |
-        bun add -d conventional-recommended-bump semver
-
-    - name: Determine new version and update package.json
-      id: version
-      shell: bash
-      run: |
-        # Step 1: Get current versions
-        echo "📦 Current Versions:"
-        current_version=$(node -p "require('./package.json').version")
-        latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n1)
-        if [ -z "$latest_tag" ]; then
-          echo "No tags found. Using v0.0.0 as base version."
-          latest_tag="v0.0.0"
-        fi
-        latest_version=${latest_tag#v}
-        
-        echo "  • package.json: v$current_version"
-        echo "  • Latest tag:   $latest_tag"
-
-        # Step 2: Show commits and compute new version
-        echo -e "\n📋 Commits since $latest_tag:"
-        git log $latest_tag..HEAD --pretty=format:"  • %s%n    %b" | sed '/^[[:space:]]*$/d'
-
-        echo -e "\n🔄 Computing next version..."
-        
-        # Install and use conventional-recommended-bump CLI
-        bunx conventional-recommended-bump -p conventionalcommits --tag-prefix v > bump_type.txt
-        bump_type=$(cat bump_type.txt)
-        
-        # Use semver CLI to compute next version
-        new_version=$(bunx semver "$latest_version" -i "$bump_type")
-        
-        # Step 3: Report versions and bump type
-        echo -e "\n📈 Version Impact:"
-        echo "  • Current:  $latest_tag"
-        echo "  • Next:     v$new_version"
-        echo "  • Type:     $bump_type bump"
-
-        # Step 4: Make changes if not in dry-run mode
-        if [ "${{ inputs.dry-run }}" = "true" ]; then
-          echo -e "\n🔍 DRY RUN - No changes will be made"
-          echo "release_needed=false" >> $GITHUB_OUTPUT
-        else
-          if [ "$current_branch" = "main" ]; then
-            echo -e "\n⚡ Applying changes..."
-            # Configure git
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git remote set-url origin "https://x-access-token:${env.GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-            
-            # Update package.json
-            jq --arg version "$new_version" '.version = $version' package.json > package.json.tmp && mv package.json.tmp package.json
-            
-            # Commit and push
-            git add package.json
-            git commit -m "chore(release): v$new_version"
-            git tag -a "v$new_version" -m "Release v$new_version"
-            git push origin HEAD:main --tags
-            
-            echo "release_needed=true" >> $GITHUB_OUTPUT
-          else
-            echo "Not on main branch - skipping release"
-            echo "release_needed=false" >> $GITHUB_OUTPUT
-          fi
-        fi
-
-        # Cleanup
-        rm -f bump_type.txt
-        echo "version=$new_version" >> $GITHUB_OUTPUT
-
-    - name: Commit and Push Changes
-      if: steps.version.outputs.release_needed == 'true'
-      shell: bash
+    - name: Determine Next Version
+      id: semver
+      uses: grumpy-programmer/conventional-commits-semver-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git commit -am "chore: release v${{ steps.version.outputs.version }}"
-        git push origin HEAD:main
-
-    - name: Generate changelog
-      id: changelog
-      if: steps.version.outputs.release_needed == 'true'
-      shell: bash
-      run: |
-        # Fetch the latest changes from the remote
-        git fetch origin main
-
-        # Check if there are any tags
-        if git describe --tags --abbrev=0 --always >/dev/null 2>&1; then
-          # Get the latest tag
-          latest_tag=$(git describe --tags --abbrev=0 --always)
-          # Generate changelog with commit messages since the latest tag up to origin/main
-          changelog=$(git log $latest_tag..origin/main --pretty=format:"%s" --no-merges)
-        else
-          # No tags found, generate changelog from the beginning of the repo up to origin/main
-          changelog=$(git log origin/main --pretty=format:"%s" --no-merges)
-        fi
-
-        # Output the changelog
-        printf "changelog<<EOF\n%s\nEOF\n" "$changelog" >> $GITHUB_ENV
+        DRY_RUN: ${{ inputs.dry-run }}
 
     - name: Create Release
-      if: steps.version.outputs.release_needed == 'true'
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        gh release create v${{ steps.version.outputs.version }} \
-          --title "Release ${{ steps.version.outputs.version }}" \
-          --notes "${{ steps.changelog.outputs.changelog }}"
+      if: ${{ inputs.dry-run != 'true' && steps.semver.outputs.released == 'true' }}
+      uses: ncipollo/release-action@v1.12.0
+      with:
+        tag_name: ${{ steps.semver.outputs.version }}
+        release_name: Release ${{ steps.semver.outputs.version }}
+        body: "See the changelog for details."
+        draft: false
+        prerelease: false
+        token: ${{ inputs.github-token }}

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -33,8 +33,9 @@ runs:
         echo "Available tags:"
         git tag -l
         
-        # Try to get the latest tag, with fallback
-        if ! latest_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+        # Get latest tag using git tag sorting
+        latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+        if [ -z "$latest_tag" ]; then
           echo "Warning: Could not find any tags. Using initial version."
           latest_tag="v0.0.0"
         fi
@@ -52,7 +53,7 @@ runs:
           jq --arg version "$latest_tag_version" '.version = $version' package.json -i
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore(release): v${{ steps.version.outputs.version }}"
+          git commit -am "chore(release): v$latest_tag_version"
           git push origin HEAD:main
         fi
 
@@ -64,27 +65,23 @@ runs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
+        # Get current version before standard-version runs
+        current_version=$(node -p "require('./package.json').version")
+        echo "Current version before standard-version: $current_version"
+
         # Use standard-version to bump version and update package.json
         if ! bunx standard-version --release-as auto --skip.tag; then
           echo "Error: Failed to determine new version"
           exit 1
         fi
 
-        # Get the new version from package.json
+        # Get the new version and validate it
         version=$(node -p "require('./package.json').version")
-        if [ -z "$version" ] || [ "$version" = "null" ]; then
-          echo "Error: Invalid version detected"
-          exit 1
-        fi
+        echo "New version after standard-version: $version"
         
-        echo "version=$version" >> $GITHUB_OUTPUT
-
-        # Check if the tag already exists
-        if git rev-parse "v$version" >/dev/null 2>&1; then
-          echo "No release necessary; the tag v$version already exists."
-          echo "release_needed=false" >> $GITHUB_OUTPUT
-        else
-          echo "release_needed=true" >> $GITHUB_OUTPUT
+        if [ -z "$version" ] || [ "$version" = "null" ] || [ "$version" = "$current_version" ]; then
+          echo "Error: Invalid or unchanged version detected"
+          exit 1
         fi
 
     - name: Commit and Push Changes

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -2,6 +2,10 @@ name: 'Create Convco Release'
 description: 'Create a new release based on Conventional Commits'
 
 inputs:
+  dry-run:
+    description: 'Run in dry-run mode without making actual changes'
+    required: false
+    default: 'false'
   github-token:
     description: 'GitHub token for creating the release'
     required: true
@@ -78,27 +82,50 @@ runs:
         fi
         echo "Latest tag: $latest_tag"
         
-        # First, update package.json to match the latest tag
-        latest_version=${latest_tag#v}
-        jq --arg version "$latest_version" '.version = $version' package.json > package.json.tmp && mv package.json.tmp package.json
+        # Create a temporary copy of package.json for dry run
+        cp package.json package.json.temp
         
-        # Now run standard-version to determine the next version
-        if ! bunx standard-version --release-as auto --skip.tag; then
+        # First, update the temporary package.json to match the latest tag
+        latest_version=${latest_tag#v}
+        jq --arg version "$latest_version" '.version = $version' package.json.temp > package.json.temp2 && mv package.json.temp2 package.json.temp
+        
+        echo "[DRY RUN] Would update package.json version to match latest tag: $latest_version"
+        
+        # Now run standard-version in dry-run mode on the temp file
+        if ! bunx standard-version --release-as auto --skip.tag --dry-run; then
           echo "Error: Failed to determine new version"
+          rm package.json.temp
           exit 1
         fi
 
-        # Get and validate the new version
-        new_version=$(node -p "require('./package.json').version")
-        echo "New version after standard-version: $new_version"
+        # Get the would-be new version
+        new_version=$(node -p "require('./package.json.temp').version")
+        echo "[DRY RUN] Would create new version: $new_version"
         
         if [ -z "$new_version" ] || [ "$new_version" = "null" ] || [ "$new_version" = "$latest_version" ]; then
           echo "Error: Invalid or unchanged version detected"
+          rm package.json.temp
           exit 1
+        fi
+
+        # Only make actual changes if not in dry-run mode
+        if [ "${{ inputs.dry-run }}" != "true" ] && [ "$current_branch" = "main" ]; then
+          echo "On main branch and not in dry-run mode - applying changes"
+          mv package.json.temp package.json
+          echo "release_needed=true" >> $GITHUB_OUTPUT
+        else
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            echo "[DRY RUN] Running in dry-run mode"
+          fi
+          echo "[DRY RUN] Changes that would be made:"
+          echo "  - Would update package.json version from $(node -p "require('./package.json').version") to $new_version"
+          echo "  - Would create new release tag v$new_version"
+          echo "  - Would generate changelog and create GitHub release"
+          rm package.json.temp
+          echo "release_needed=false" >> $GITHUB_OUTPUT
         fi
         
         echo "version=$new_version" >> $GITHUB_OUTPUT
-        echo "release_needed=true" >> $GITHUB_OUTPUT
 
     - name: Commit and Push Changes
       if: steps.version.outputs.release_needed == 'true'

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -29,11 +29,14 @@ runs:
       with:
         plugins: '["bun@latest"]'
 
+    - name: Install version computation dependencies
+      shell: bash
+      run: |
+        bun add -d conventional-recommended-bump semver
+
     - name: Determine new version and update package.json
       id: version
       shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         # Step 1: Get current versions
         echo "📦 Current Versions:"
@@ -48,49 +51,20 @@ runs:
         echo "  • package.json: v$current_version"
         echo "  • Latest tag:   $latest_tag"
 
-        # Step 2: Compute new version
+        # Step 2: Show commits and compute new version
         echo -e "\n📋 Commits since $latest_tag:"
-        # Include merge commits and show full commit messages
         git log $latest_tag..HEAD --pretty=format:"  • %s%n    %b" | sed '/^[[:space:]]*$/d'
 
         echo -e "\n🔄 Computing next version..."
-        # Create a temporary copy of package.json for version computation
-        cp package.json package.json.temp
-        jq --arg version "$latest_version" '.version = $version' package.json.temp > package.json.temp2 && mv package.json.temp2 package.json.temp
-
-        # Use standard-version to compute next version
-        if ! bunx standard-version \
-          --dry-run \
-          --skip.commit \
-          --skip.tag \
-          --skip.changelog \
-          --release-as auto \
-          > version_output.txt 2>&1; then
-          echo "Error: Failed to determine new version"
-          cat version_output.txt  # Show the error output
-          rm -f package.json.temp version_output.txt
-          exit 1
-        fi
-
-        # Extract the computed new version and validate it
-        new_version=$(grep "bumping version in package.json from" version_output.txt | awk -F "to " '{print $2}')
-        if [ -z "$new_version" ] || [ "$new_version" = "null" ]; then
-          echo "Error: Failed to compute new version"
-          echo "standard-version output:"
-          cat version_output.txt
-          rm -f package.json.temp version_output.txt
-          exit 1
-        fi
+        
+        # Install and use conventional-recommended-bump CLI
+        bunx conventional-recommended-bump -p conventionalcommits --tag-prefix v > bump_type.txt
+        bump_type=$(cat bump_type.txt)
+        
+        # Use semver CLI to compute next version
+        new_version=$(bunx semver "$latest_version" -i "$bump_type")
         
         # Step 3: Report versions and bump type
-        if [ "$(echo $latest_version | cut -d. -f1)" != "$(echo $new_version | cut -d. -f1)" ]; then
-          bump_type="major"
-        elif [ "$(echo $latest_version | cut -d. -f2)" != "$(echo $new_version | cut -d. -f2)" ]; then
-          bump_type="minor"
-        else
-          bump_type="patch"
-        fi
-        
         echo -e "\n📈 Version Impact:"
         echo "  • Current:  $latest_tag"
         echo "  • Next:     v$new_version"
@@ -108,11 +82,14 @@ runs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git remote set-url origin "https://x-access-token:${env.GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             
-            # Run standard-version for real
-            if ! bunx standard-version --release-as auto --skip.tag; then
-              echo "Error: Failed to create release"
-              exit 1
-            fi
+            # Update package.json
+            jq --arg version "$new_version" '.version = $version' package.json > package.json.tmp && mv package.json.tmp package.json
+            
+            # Commit and push
+            git add package.json
+            git commit -m "chore(release): v$new_version"
+            git tag -a "v$new_version" -m "Release v$new_version"
+            git push origin HEAD:main --tags
             
             echo "release_needed=true" >> $GITHUB_OUTPUT
           else
@@ -122,7 +99,7 @@ runs:
         fi
 
         # Cleanup
-        rm -f package.json.temp version_output.txt
+        rm -f bump_type.txt
         echo "version=$new_version" >> $GITHUB_OUTPUT
 
     - name: Commit and Push Changes

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -65,10 +65,17 @@ runs:
     - name: Determine new version and update package.json
       id: version
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         # Configure git user
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
+
+        if [ "${{ inputs.dry-run }}" != "true" ] && [ "$current_branch" = "main" ]; then
+          # Configure git to use the token (only when actually making changes)
+          git remote set-url origin "https://x-access-token:${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+        fi
 
         # Get current branch name
         current_branch=$(git rev-parse --abbrev-ref HEAD)
@@ -80,51 +87,62 @@ runs:
           echo "No tags found. Using v0.0.0 as base version."
           latest_tag="v0.0.0"
         fi
-        echo "Latest tag: $latest_tag"
         
-        # Create a temporary copy of package.json for dry run
+        # Get current package.json version
+        current_version=$(node -p "require('./package.json').version")
+        
+        echo "📦 Current Versions:"
+        echo "  • package.json: v$current_version"
+        echo "  • Latest tag:   $latest_tag"
+        
+        # Create a temporary copy of package.json for version computation
         cp package.json package.json.temp
         
         # First, update the temporary package.json to match the latest tag
         latest_version=${latest_tag#v}
         jq --arg version "$latest_version" '.version = $version' package.json.temp > package.json.temp2 && mv package.json.temp2 package.json.temp
         
-        echo "[DRY RUN] Would update package.json version to match latest tag: $latest_version"
-        
-        # Now run standard-version in dry-run mode on the temp file
-        if ! bunx standard-version --release-as auto --skip.tag --dry-run; then
+        # Get conventional commits since last tag for analysis
+        echo -e "\n📋 Commits since $latest_tag:"
+        git log $latest_tag..HEAD --pretty=format:"  • %s" --no-merges
+
+        # Run standard-version in dry-run mode to determine next version
+        echo -e "\n🔄 Computing next version..."
+        if ! bunx standard-version --release-as auto --skip.tag --dry-run > version_output.txt 2>&1; then
           echo "Error: Failed to determine new version"
-          rm package.json.temp
+          rm package.json.temp version_output.txt
           exit 1
         fi
 
-        # Get the would-be new version
+        # Extract the computed new version
         new_version=$(node -p "require('./package.json.temp').version")
-        echo "[DRY RUN] Would create new version: $new_version"
         
-        if [ -z "$new_version" ] || [ "$new_version" = "null" ] || [ "$new_version" = "$latest_version" ]; then
-          echo "Error: Invalid or unchanged version detected"
-          rm package.json.temp
-          exit 1
+        # Determine bump type by comparing versions
+        if [ "$(echo $latest_version | cut -d. -f1)" != "$(echo $new_version | cut -d. -f1)" ]; then
+          bump_type="major"
+        elif [ "$(echo $latest_version | cut -d. -f2)" != "$(echo $new_version | cut -d. -f2)" ]; then
+          bump_type="minor"
+        else
+          bump_type="patch"
         fi
+        
+        echo -e "\n📈 Version Impact:"
+        echo "  • Current:  $latest_tag"
+        echo "  • Next:     v$new_version"
+        echo "  • Type:     $bump_type bump"
 
-        # Only make actual changes if not in dry-run mode
         if [ "${{ inputs.dry-run }}" != "true" ] && [ "$current_branch" = "main" ]; then
-          echo "On main branch and not in dry-run mode - applying changes"
+          echo -e "\n⚡ Applying changes..."
           mv package.json.temp package.json
           echo "release_needed=true" >> $GITHUB_OUTPUT
         else
-          if [ "${{ inputs.dry-run }}" = "true" ]; then
-            echo "[DRY RUN] Running in dry-run mode"
-          fi
-          echo "[DRY RUN] Changes that would be made:"
-          echo "  - Would update package.json version from $(node -p "require('./package.json').version") to $new_version"
-          echo "  - Would create new release tag v$new_version"
-          echo "  - Would generate changelog and create GitHub release"
+          echo -e "\n🔍 DRY RUN - No changes will be made"
           rm package.json.temp
           echo "release_needed=false" >> $GITHUB_OUTPUT
         fi
         
+        # Cleanup
+        rm -f version_output.txt
         echo "version=$new_version" >> $GITHUB_OUTPUT
 
     - name: Commit and Push Changes

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -68,14 +68,9 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        # Configure git user
+        # Configure git user (needed for standard-version)
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-
-        if [ "${{ inputs.dry-run }}" != "true" ] && [ "$current_branch" = "main" ]; then
-          # Configure git to use the token (only when actually making changes)
-          git remote set-url origin "https://x-access-token:${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-        fi
 
         # Get current branch name
         current_branch=$(git rev-parse --abbrev-ref HEAD)
@@ -108,7 +103,7 @@ runs:
 
         # Run standard-version in dry-run mode to determine next version
         echo -e "\n🔄 Computing next version..."
-        if ! bunx standard-version --release-as auto --skip.tag --dry-run > version_output.txt 2>&1; then
+        if ! bunx standard-version --release-as auto --skip.tag --dry-run --skip.commit > version_output.txt 2>&1; then
           echo "Error: Failed to determine new version"
           rm package.json.temp version_output.txt
           exit 1
@@ -133,6 +128,15 @@ runs:
 
         if [ "${{ inputs.dry-run }}" != "true" ] && [ "$current_branch" = "main" ]; then
           echo -e "\n⚡ Applying changes..."
+          # Configure git to use the token (only when actually making changes)
+          git remote set-url origin "https://x-access-token:${env.GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          
+          # Now run standard-version for real
+          if ! bunx standard-version --release-as auto --skip.tag; then
+            echo "Error: Failed to create release"
+            exit 1
+          fi
+          
           mv package.json.temp package.json
           echo "release_needed=true" >> $GITHUB_OUTPUT
         else

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -5,18 +5,14 @@ inputs:
   github-token:
     description: 'GitHub token for creating the release'
     required: true
-  dry-run:
-    description: 'Run in dry-run mode without making actual changes'
-    required: false
-    default: 'false'
 
 outputs:
-  version:
-    description: 'The version that was or would be released'
-    value: ${{ steps.semver.outputs.version }}
-  release_needed:
-    description: 'Whether a release is needed'
+  release_created:
+    description: 'Whether a release was created'
     value: ${{ steps.semver.outputs.released }}
+  version:
+    description: 'The version that was released'
+    value: ${{ steps.semver.outputs.version }}
 
 runs:
   using: "composite"
@@ -31,15 +27,14 @@ runs:
       uses: grumpy-programmer/conventional-commits-semver-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        DRY_RUN: ${{ inputs.dry-run }}
 
     - name: Create Release
-      if: ${{ inputs.dry-run != 'true' && steps.semver.outputs.released == 'true' }}
+      if: ${{ steps.semver.outputs.released == 'true' }}
       uses: ncipollo/release-action@v1.12.0
       with:
-        tag_name: ${{ steps.semver.outputs.version }}
-        release_name: Release ${{ steps.semver.outputs.version }}
         body: "See the changelog for details."
         draft: false
         prerelease: false
+        release_name: Release ${{ steps.semver.outputs.version }}
+        tag_name: ${{ steps.semver.outputs.version }}
         token: ${{ inputs.github-token }}

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Fetch all tags
       run: |
-        git fetch --prune --unshallow --tags origin
+        git fetch --prune --tags origin
         git fetch --all
       shell: bash
 

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -29,115 +29,91 @@ runs:
       with:
         plugins: '["bun@latest"]'
 
-    - name: Sync package.json version with latest tag
-      id: sync-version
-      shell: bash
-      run: |
-        # List tags for debugging
-        echo "Available tags:"
-        git tag -l
-        
-        # Get latest tag using git tag sorting
-        latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n1)
-        if [ -z "$latest_tag" ]; then
-          echo "Warning: Could not find any tags. Using initial version."
-          latest_tag="v0.0.0"
-        fi
-        
-        echo "Latest tag: $latest_tag"
-        latest_tag_version=${latest_tag#v}
-        
-        # Get the current package.json version
-        package_version=$(node -p "require('./package.json').version")
-        echo "Package.json version: $package_version"
-
-        # Compare and update package.json if necessary
-        if [ "$(printf '%s\n' "$latest_tag_version" "$package_version" | sort -V | head -n1)" != "$latest_tag_version" ]; then
-          echo "Updating package.json version from $package_version to $latest_tag_version"
-          jq --arg version "$latest_tag_version" '.version = $version' package.json > package.json.tmp && mv package.json.tmp package.json
-          
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore(release): v$latest_tag_version"
-          git push origin HEAD:main
-        fi
-
     - name: Determine new version and update package.json
       id: version
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        # Configure git user (needed for standard-version)
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-
-        # Get current branch name
-        current_branch=$(git rev-parse --abbrev-ref HEAD)
-        echo "Current branch: $current_branch"
-        
-        # Get latest tag using git tag sorting
+        # Step 1: Get current versions
+        echo "📦 Current Versions:"
+        current_version=$(node -p "require('./package.json').version")
         latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n1)
         if [ -z "$latest_tag" ]; then
           echo "No tags found. Using v0.0.0 as base version."
           latest_tag="v0.0.0"
         fi
+        latest_version=${latest_tag#v}
         
-        # Get current package.json version
-        current_version=$(node -p "require('./package.json').version")
-        
-        echo "📦 Current Versions:"
         echo "  • package.json: v$current_version"
         echo "  • Latest tag:   $latest_tag"
 
-        if [ "${{ inputs.dry-run }}" = "true" ]; then
-          # DRY RUN MODE
-          # Create a temporary copy of package.json for version computation
-          cp package.json package.json.temp
-          latest_version=${latest_tag#v}
-          
-          echo -e "\n📋 Commits since $latest_tag:"
-          git log $latest_tag..HEAD --pretty=format:"  • %s" --no-merges
+        # Step 2: Compute new version
+        echo -e "\n📋 Commits since $latest_tag:"
+        git log $latest_tag..HEAD --pretty=format:"  • %s" --no-merges
 
-          echo -e "\n🔄 Computing next version..."
-          # Use standard-version with all git operations disabled
-          if ! bunx standard-version \
-            --dry-run \
-            --skip.commit \
-            --skip.tag \
-            --skip.changelog \
-            --release-as auto \
-            > version_output.txt 2>&1; then
-            echo "Error: Failed to determine new version"
-            rm package.json.temp version_output.txt
-            exit 1
-          fi
+        echo -e "\n🔄 Computing next version..."
+        # Create a temporary copy of package.json for version computation
+        cp package.json package.json.temp
+        jq --arg version "$latest_version" '.version = $version' package.json.temp > package.json.temp2 && mv package.json.temp2 package.json.temp
 
-          # Extract the computed new version from the output
-          new_version=$(grep "bumping version in package.json from" version_output.txt | awk -F "to " '{print $2}')
-          
-          # Determine bump type
-          if [ "$(echo $latest_version | cut -d. -f1)" != "$(echo $new_version | cut -d. -f1)" ]; then
-            bump_type="major"
-          elif [ "$(echo $latest_version | cut -d. -f2)" != "$(echo $new_version | cut -d. -f2)" ]; then
-            bump_type="minor"
-          else
-            bump_type="patch"
-          fi
-          
-          echo -e "\n📈 Version Impact:"
-          echo "  • Current:  $latest_tag"
-          echo "  • Next:     v$new_version"
-          echo "  • Type:     $bump_type bump"
-          echo -e "\n🔍 DRY RUN - No changes will be made"
-          
+        # Use standard-version to compute next version
+        if ! bunx standard-version \
+          --dry-run \
+          --skip.commit \
+          --skip.tag \
+          --skip.changelog \
+          --release-as auto \
+          > version_output.txt 2>&1; then
+          echo "Error: Failed to determine new version"
           rm -f package.json.temp version_output.txt
-          echo "release_needed=false" >> $GITHUB_OUTPUT
+          exit 1
+        fi
 
+        # Extract the computed new version
+        new_version=$(grep "bumping version in package.json from" version_output.txt | awk -F "to " '{print $2}')
+        
+        # Step 3: Report versions and bump type
+        if [ "$(echo $latest_version | cut -d. -f1)" != "$(echo $new_version | cut -d. -f1)" ]; then
+          bump_type="major"
+        elif [ "$(echo $latest_version | cut -d. -f2)" != "$(echo $new_version | cut -d. -f2)" ]; then
+          bump_type="minor"
         else
-          # ... rest of the actual release code ...
+          bump_type="patch"
         fi
         
+        echo -e "\n📈 Version Impact:"
+        echo "  • Current:  $latest_tag"
+        echo "  • Next:     v$new_version"
+        echo "  • Type:     $bump_type bump"
+
+        # Step 4: Make changes if not in dry-run mode
+        if [ "${{ inputs.dry-run }}" = "true" ]; then
+          echo -e "\n🔍 DRY RUN - No changes will be made"
+          echo "release_needed=false" >> $GITHUB_OUTPUT
+        else
+          if [ "$current_branch" = "main" ]; then
+            echo -e "\n⚡ Applying changes..."
+            # Configure git
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git remote set-url origin "https://x-access-token:${env.GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            
+            # Run standard-version for real
+            if ! bunx standard-version --release-as auto --skip.tag; then
+              echo "Error: Failed to create release"
+              exit 1
+            fi
+            
+            echo "release_needed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Not on main branch - skipping release"
+            echo "release_needed=false" >> $GITHUB_OUTPUT
+          fi
+        fi
+
+        # Cleanup
+        rm -f package.json.temp version_output.txt
         echo "version=$new_version" >> $GITHUB_OUTPUT
 
     - name: Commit and Push Changes

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -66,24 +66,35 @@ runs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
-        # Get current version before standard-version runs
-        current_version=$(node -p "require('./package.json').version")
-        echo "Current version before standard-version: $current_version"
-
-        # Use standard-version to bump version and update package.json
+        # Get latest tag using git tag sorting
+        latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+        if [ -z "$latest_tag" ]; then
+          echo "No tags found. Using v0.0.0 as base version."
+          latest_tag="v0.0.0"
+        fi
+        echo "Latest tag: $latest_tag"
+        
+        # First, update package.json to match the latest tag
+        latest_version=${latest_tag#v}
+        jq --arg version "$latest_version" '.version = $version' package.json > package.json.tmp && mv package.json.tmp package.json
+        
+        # Now run standard-version to determine the next version
         if ! bunx standard-version --release-as auto --skip.tag; then
           echo "Error: Failed to determine new version"
           exit 1
         fi
 
-        # Get the new version and validate it
-        version=$(node -p "require('./package.json').version")
-        echo "New version after standard-version: $version"
+        # Get and validate the new version
+        new_version=$(node -p "require('./package.json').version")
+        echo "New version after standard-version: $new_version"
         
-        if [ -z "$version" ] || [ "$version" = "null" ] || [ "$version" = "$current_version" ]; then
+        if [ -z "$new_version" ] || [ "$new_version" = "null" ] || [ "$new_version" = "$latest_version" ]; then
           echo "Error: Invalid or unchanged version detected"
           exit 1
         fi
+        
+        echo "version=$new_version" >> $GITHUB_OUTPUT
+        echo "release_needed=true" >> $GITHUB_OUTPUT
 
     - name: Commit and Push Changes
       if: steps.version.outputs.release_needed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,15 +63,3 @@ jobs:
           else
             echo "All required jobs have passed or were skipped!"
           fi
-
-  check-release-impact:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Check Release Impact
-        uses: ./.github/actions/create-release
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          dry-run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,11 @@ jobs:
             echo "All required jobs have passed or were skipped!"
           fi
 
+  check-release-impact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Release Impact
+        uses: ./.github/actions/create-release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
   check-release-impact:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Check Release Impact
         uses: ./.github/actions/create-release
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
 
 permissions:
+  contents: write
   issues: write
   pull-requests: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 on:
+  pull_request:
+    branches: [ 'main' ]
   push:
     branches: [ 'main' ]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  pull_request:
-    branches: [ 'main' ]
   push:
     branches: [ 'main' ]
   workflow_dispatch:


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow for creating releases and minor changes to the CI workflow permissions. The most important changes involve simplifying the release creation process by using a dedicated action for version determination and release creation, and adding outputs to the release action.

Changes to release creation workflow:

* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L1-R40): Updated the action name and description, added outputs for `release_created` and `version`, and simplified the steps by integrating the `conventional-commits-semver-release` action for version determination and the `release-action` for creating releases.

Changes to CI workflow permissions:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR9): Added `contents: write` permission to the CI workflow.

Minor cleanup:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL65): Removed an unnecessary blank line in the `jobs:` section.