### PR TITLE
ci(): remove extra script

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -27,14 +27,3 @@ runs:
       uses: grumpy-programmer/conventional-commits-semver-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-
-    - name: Create Release
-      if: ${{ steps.semver.outputs.released == 'true' }}
-      uses: ncipollo/release-action@v1.12.0
-      with:
-        body: "See the changelog for details."
-        draft: false
-        prerelease: false
-        release_name: Release ${{ steps.semver.outputs.version }}
-        tag_name: ${{ steps.semver.outputs.version }}
-        token: ${{ inputs.github-token }}


### PR DESCRIPTION
This pull request includes a minor change to the GitHub Actions workflow configuration. The change removes the step for creating a release using the `ncipollo/release-action` in the `.github/actions/create-release/action.yml` file.

Changes to GitHub Actions workflow:

* Removed the step for creating a release using `ncipollo/release-action` from the `runs:` section in `.github/actions/create-release/action.yml`.