### PR TITLE
ci()!: update publish-packages script

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -53,14 +53,30 @@ jobs:
           echo "packages=$packages" >> $GITHUB_OUTPUT
 
       - name: Build All Packages
+        id: build
         run: |
           packages='${{ steps.workspaces.outputs.packages }}'
           version='${{ steps.latest_tag.outputs.tag }}'
+          failed_packages=()
           
           for package in $(echo "$packages" | jq -r '.[]'); do
             echo "Building $package@$version"
-            bun workspace build "$package" -v "$version"
+            if bun workspace build "$package" -v "$version"; then
+              echo "✅ Successfully built $package"
+            else
+              echo "::error::Failed to build $package"
+              failed_packages+=("$package")
+            fi
           done
+          
+          if [ ${#failed_packages[@]} -gt 0 ]; then
+            echo "::group::Failed Package Builds"
+            echo "The following packages failed to build:"
+            printf '%s\n' "${failed_packages[@]}"
+            echo "::endgroup::"
+            echo "failed_packages=${failed_packages[*]}" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
       - name: Publish Packages
         if: inputs.shouldPublish && steps.npm_token.outputs.token_exists == 'true'


### PR DESCRIPTION
This pull request includes an update to the `publish-packages.yml` workflow to improve the build process for packages. The key change is the addition of error handling and reporting for package builds.

Enhancements to package build process:

* Added an `id` to the "Build All Packages" step for better identification.
* Introduced error handling to capture and report failed package builds. If any package fails to build, the workflow will now log the failed packages and exit with an error.