### PR TITLE
feat: actions/asdf-setup should cache asdf installations

### DIFF
--- a/.github/actions/asdf-setup/README.md
+++ b/.github/actions/asdf-setup/README.md
@@ -33,10 +33,20 @@ jobs:
 
 1. **Checkout Code**: Uses the `actions/checkout` action to clone the repository.
 2. **Setup ASDF**: Uses the `asdf-vm/actions/setup` action to set up ASDF.
-3. **Install ASDF Plugins & Tools**: Installs plugins and tools listed in `.tool-versions`.
-4. **Determine Package Manager**: Identifies the package manager and lock file used in the project.
-5. **Cache Dependencies**: Caches the `node_modules` directory based on the lock file.
-6. **Install Dependencies**: Installs project dependencies using the identified package manager.
+3. **Cache ASDF Components**: Caches ASDF plugins and shims to speed up workflow execution.
+4. **Install ASDF Plugins & Tools**: Installs plugins and tools listed in `.tool-versions`.
+5. **Determine Package Manager**: Identifies the package manager and lock file used in the project.
+6. **Cache Dependencies**: Caches the `node_modules` directory based on the lock file.
+7. **Install Dependencies**: Installs project dependencies using the identified package manager.
+
+## Caching Strategy
+
+The action implements two-level caching for ASDF components:
+
+- **Plugins Cache**: Caches the `~/.asdf/plugins` directory to avoid re-downloading plugins on subsequent runs
+- **Shims Cache**: Caches the `~/.asdf/shims` directory to preserve executable shortcuts
+
+Both caches are keyed based on the operating system and the contents of `.tool-versions` file, ensuring cache invalidation when tools are updated.
 
 ## Notes
 

--- a/.github/actions/asdf-setup/README.md
+++ b/.github/actions/asdf-setup/README.md
@@ -41,7 +41,7 @@ jobs:
 
 ## Caching Strategy
 
-The action implements two-level caching for ASDF components:
+The action implements caching for ASDF components:
 
 - **Plugins Cache**: Caches the `~/.asdf/plugins` directory to avoid re-downloading plugins on subsequent runs
 - **Shims Cache**: Caches the `~/.asdf/shims` directory to preserve executable shortcuts

--- a/.github/actions/asdf-setup/action.yml
+++ b/.github/actions/asdf-setup/action.yml
@@ -14,6 +14,22 @@ runs:
     - uses: actions/checkout@v4
     - uses: asdf-vm/actions/setup@v3
 
+    - name: Cache ASDF plugins
+      uses: actions/cache@v4
+      with:
+        path: ~/.asdf/plugins
+        key: ${{ runner.os }}-asdf-plugins-${{ hashFiles('.tool-versions') }}
+        restore-keys: |
+          ${{ runner.os }}-asdf-plugins-
+
+    - name: Cache ASDF shims
+      uses: actions/cache@v4
+      with:
+        path: ~/.asdf/shims
+        key: ${{ runner.os }}-asdf-shims-${{ hashFiles('.tool-versions') }}
+        restore-keys: |
+          ${{ runner.os }}-asdf-shims-
+
     - name: Install ASDF plugins & tools
       shell: bash
       run: |


### PR DESCRIPTION
This pull request introduces changes to the ASDF setup action to improve caching strategies and streamline the workflow. The most important changes include adding caching for ASDF components and updating the workflow steps accordingly.

Improvements to caching strategy:

* [`.github/actions/asdf-setup/README.md`](diffhunk://#diff-ac242ce264ea30698c028781528de67596ce84c953eb6a05efbde6ccb610c977L36-R49): Added a new caching strategy section describing two-level caching for ASDF components, including plugins and shims. Updated the workflow steps to include caching ASDF components before installing plugins and tools.
* [`.github/actions/asdf-setup/action.yml`](diffhunk://#diff-ddfd25f88e6634d4be9cc1cb6aee1b098a2d19477910edc1f144077fe26f8c9bR17-R32): Added steps to cache ASDF plugins and shims using `actions/cache@v4` to avoid re-downloading plugins and preserve executable shortcuts, respectively.