### PR TITLE
ci: fix npm-publish

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -80,7 +80,11 @@ jobs:
 
       - name: Publish Packages
         if: inputs.shouldPublish && steps.npm_token.outputs.token_exists == 'true'
+        shell: bash
         run: |
+          # Ensure jq is in PATH
+          source ~/.asdf/asdf.sh
+          
           packages='${{ steps.workspaces.outputs.packages }}'
           version='${{ steps.latest_tag.outputs.tag }}'
           


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/publish-packages.yml` file. The change ensures that the `jq` tool is available in the PATH during the publish packages step.

* [`.github/workflows/publish-packages.yml`](diffhunk://#diff-f649dfa0883378db13b96d378fbaedfaf99e75a92d0962d813575b79643dd01bR83-R87): Added a shell declaration and a command to source `asdf.sh` to ensure `jq` is in the PATH.