### PR TITLE
ci: fix build order

### DIFF
--- a/.github/actions/asdf-setup/action.yml
+++ b/.github/actions/asdf-setup/action.yml
@@ -70,6 +70,10 @@ runs:
         # Reshim all tools
         asdf reshim
 
+        # Add ASDF to shell environment
+        echo 'source ~/.asdf/asdf.sh' >> $GITHUB_ENV
+        source ~/.asdf/asdf.sh
+
     - name: Determine package manager and set cache key
       id: pkg-manager
       shell: bash

--- a/.github/actions/asdf-setup/action.yml
+++ b/.github/actions/asdf-setup/action.yml
@@ -70,9 +70,11 @@ runs:
         # Reshim all tools
         asdf reshim
 
-        # Add ASDF to shell environment
-        echo 'source ~/.asdf/asdf.sh' >> $GITHUB_ENV
-        source ~/.asdf/asdf.sh
+        # Add ASDF paths to environment
+        echo "ASDF_DIR=${HOME}/.asdf" >> $GITHUB_ENV
+        echo "ASDF_DATA_DIR=${HOME}/.asdf" >> $GITHUB_ENV
+        echo "${HOME}/.asdf/shims" >> $GITHUB_PATH
+        echo "${HOME}/.asdf/bin" >> $GITHUB_PATH
 
     - name: Determine package manager and set cache key
       id: pkg-manager

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -52,7 +52,17 @@ jobs:
           packages=$(bun workspace list --only '^@basis/')
           echo "packages=$packages" >> $GITHUB_OUTPUT
 
-      - name: Build All Packages
+      - name: Build @basis/bun-plugins
+        run: |
+          version='${{ steps.latest_tag.outputs.tag }}'
+          echo "Building @basis/bun-plugins@$version"
+          if ! bun workspace build "@basis/bun-plugins" -v "$version"; then
+            echo "::error::Failed to build @basis/bun-plugins"
+            exit 1
+          fi
+          echo "✅ Successfully built @basis/bun-plugins"
+
+      - name: Build Remaining Packages
         id: build
         run: |
           packages='${{ steps.workspaces.outputs.packages }}'
@@ -60,6 +70,11 @@ jobs:
           failed_packages=()
           
           for package in $(echo "$packages" | jq -r '.[]'); do
+            # Skip bun-plugins as it's already built
+            if [ "$package" = "@basis/bun-plugins" ]; then
+              continue
+            fi
+            
             echo "Building $package@$version"
             if bun workspace build "$package" -v "$version"; then
               echo "✅ Successfully built $package"
@@ -82,9 +97,6 @@ jobs:
         if: inputs.shouldPublish && steps.npm_token.outputs.token_exists == 'true'
         shell: bash
         run: |
-          # Ensure jq is in PATH
-          source ~/.asdf/asdf.sh
-          
           packages='${{ steps.workspaces.outputs.packages }}'
           version='${{ steps.latest_tag.outputs.tag }}'
           


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions and workflows to enhance the setup and build processes for the project. The most important changes include adding ASDF paths to the environment and splitting the build process for `@basis/bun-plugins` from the other packages.

Enhancements to GitHub Actions setup:

* [`.github/actions/asdf-setup/action.yml`](diffhunk://#diff-ddfd25f88e6634d4be9cc1cb6aee1b098a2d19477910edc1f144077fe26f8c9bR73-R78): Added commands to set ASDF paths in the environment variables and update the GitHub path.

Improvements to package build workflow:

* [`.github/workflows/publish-packages.yml`](diffhunk://#diff-f649dfa0883378db13b96d378fbaedfaf99e75a92d0962d813575b79643dd01bL55-R77): Split the build process to handle `@basis/bun-plugins` separately from the other packages, ensuring better error handling and clearer build logs.
* [`.github/workflows/publish-packages.yml`](diffhunk://#diff-f649dfa0883378db13b96d378fbaedfaf99e75a92d0962d813575b79643dd01bL85-L87): Removed unnecessary sourcing of `asdf.sh` script since `jq` is no longer required in the path for the publish step.