### PR TITLE
ci: improve build error logging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,13 @@ jobs:
           
           for workspace in $(echo "$workspaces" | jq -r '.[]'); do
             echo "Building $workspace@$version"
-            build_output=$(bun workspace build "$workspace" -v "$version" 2>&1)
+            
+            # Run build and capture its exit status
+            build_output=$(bun workspace build "$workspace" -v "$version" 2>&1) || {
+              echo "::error::Build failed for $workspace"
+              echo "$build_output"
+              exit 1
+            }
             
             if [[ "$build_output" == *"SKIP"* ]]; then
               echo "⚠️ Build script is set to SKIP for $workspace. Skipping."
@@ -84,6 +90,9 @@ jobs:
             
             echo "Publishing $workspace@$version"
             cd "$(bun workspace find "$workspace")"
-            bun publish --access public --tag latest
+            bun publish --access public --tag latest || {
+              echo "::error::Failed to publish $workspace"
+              exit 1
+            }
             cd -
           done


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to improve error handling during the build and publish processes. The most important changes are:

Error handling improvements:

* Added error handling for the build process to capture the exit status and print an error message if the build fails. (`.github/workflows/release.yml`)
* Added error handling for the publish process to print an error message and exit if the publish fails. (`.github/workflows/release.yml`)