### PR TITLE
ci: homegrown semver version bump

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -9,21 +9,36 @@ inputs:
 outputs:
   released:
     description: 'Whether a release was created'
-    value: ${{ steps.semver.outputs.released }}
+    value: ${{ steps.version.outputs.released }}
   version:
     description: 'The version that was released'
-    value: ${{ steps.semver.outputs.version }}
+    value: ${{ steps.version.outputs.version }}
 
 runs:
   using: "composite"
   steps:
-    - name: Checkout with full history
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v1
+
+    - name: Setup Action
+      shell: bash
+      run: |
+        TEMP_DIR=$(mktemp -d)
+        cp ${{ github.action_path }}/*.ts "$TEMP_DIR/"
+        echo "ACTION_TEMP_DIR=$TEMP_DIR" >> $GITHUB_ENV
 
     - name: Determine Next Version
-      id: semver
-      uses: grumpy-programmer/conventional-commits-semver-release@v1
+      id: version
+      shell: bash
+      run: bun run "$ACTION_TEMP_DIR/getNextVersion.ts"
+
+    - name: Create GitHub Release
+      if: steps.version.outputs.released == 'true'
+      shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        version="${{ steps.version.outputs.version }}"
+        gh release create "$version" \
+          --title "$version" \
+          --generate-notes

--- a/.github/actions/create-release/getNextVersion.ts
+++ b/.github/actions/create-release/getNextVersion.ts
@@ -1,0 +1,97 @@
+/* eslint-disable no-console */
+import { $ } from 'bun'
+import { getUnreleasedCommitMessages, isMinorChange, isPatchChange } from './getUnreleasedCommitMessages'
+
+/** A SemVer version */
+interface Version {
+  /** The major version */
+  major: number,
+  /** The minor version */
+  minor: number,
+  /** The patch version */
+  patch: number,
+}
+
+/**
+ * Parse a version string into a Version object
+ * @param version - The version string
+ * @returns The parsed version
+ */
+function parseVersion(version: string): Version {
+  const [major = 0, minor = 0, patch = 0] = version
+    .replace(/^v/, '')
+    .split('.')
+    .map(Number)
+  return { major, minor, patch }
+}
+
+/**
+ * Format a Version object into a version string
+ * @param version - The Version object
+ * @returns The formatted version string
+ */
+function formatVersion(version: Version): string {
+  return `v${version.major}.${version.minor}.${version.patch}`
+}
+
+/**
+ * Get the current version from the git repository
+ * @returns The current version
+ */
+async function getCurrentVersion(): Promise<string> {
+  try {
+    const { stdout } = await Bun.spawn(['git', 'describe', '--tags', '--abbrev=0'], {
+      stdout: 'pipe',
+    })
+    return new TextDecoder().decode(await stdout.getReader().read().then(r => r.value)) || 'v0.0.0'
+  } catch {
+    return 'v0.0.0'
+  }
+}
+
+/** Determine the next version based on the unreleased commit messages */
+async function main() {
+  const commits = await getUnreleasedCommitMessages()
+  if (commits.length === 0) {
+    console.log('No unreleased commits found')
+    process.exit(0)
+  } else {
+    console.log('Unreleased commits found:')
+    console.log(commits
+      .filter(commit => commit.title)
+      .map(commit => (
+        commit.title.length > 75
+          ? `${commit.type}: ${commit.title.slice(0, 75)}...`
+          : `${commit.type}: ${commit.title}`
+      ))
+      .join('\n'))
+  }
+
+  const currentVersion = await getCurrentVersion()
+  const version = parseVersion(currentVersion)
+
+  // Check for breaking changes
+  if (commits.some(commit => commit.breaking)) {
+    version.major++
+    version.minor = 0
+    version.patch = 0
+  } else if (commits.some(commit => isMinorChange(commit.type))) {
+    version.minor++
+    version.patch = 0
+  } else if (commits.some(commit => isPatchChange(commit.type))) {
+    version.patch++
+  } else {
+    // No version bump needed
+    console.log('No version bump needed')
+    process.exit(0)
+  }
+
+  const nextVersion = formatVersion(version)
+  await $`echo "version=${nextVersion}" >> $GITHUB_OUTPUT`
+  await $`echo "released=true" >> $GITHUB_OUTPUT`
+}
+
+main().catch(error => {
+  console.error('Failed to determine next version:', error)
+  process.exit(1)
+})

--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -1,0 +1,132 @@
+import { $ } from 'bun'
+
+/** The type of conventional commit */
+export enum ChangeType {
+  Build = 'build',
+  CI = 'ci',
+  Chore = 'chore',
+  Docs = 'docs',
+  Feat = 'feat',
+  Fix = 'fix',
+  Perf = 'perf',
+  Refactor = 'refactor',
+  Revert = 'revert',
+  Style = 'style',
+  Test = 'test',
+  Unknown = 'unknown',
+}
+
+/** A parsed conventional commit message */
+export interface ConventionalCommit {
+  /** Whether this is a breaking change */
+  breaking: boolean,
+  /** The commit description (PR body) */
+  description?: string,
+  /** The optional scope */
+  scope?: string,
+  /** The commit title (without type prefix) */
+  title: string,
+  /** The commit type (feat, fix, etc.) */
+  type: ChangeType,
+}
+
+/**
+ * Get all commit messages since the last release tag
+ * @returns Array of conventional commit messages
+ */
+export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[]> {
+  try {
+    await $`git fetch --tags origin`.quiet()
+
+    // Get the latest release tag
+    const latestTag = (await $`git describe --tags --abbrev=0`.text()).trim()
+
+    // If no tag exists, get all commits
+    const range = latestTag
+      ? `${latestTag}..HEAD`
+      : 'HEAD'
+
+    /*
+     * Get all commit messages since the last tag
+     * Use %x1E as a commit separator and %x1F as a title/body separator
+     */
+    const output = await $`git log ${range} --format=%s%x1F%b%x1E`.text()
+    const commits = output.split('\x1E').filter(Boolean).map(commit => {
+      const [title, body = ''] = commit.split('\x1F')
+      return { description: body.trim(), title: title.trim() }
+    })
+
+    // Parse conventional commits
+    return commits.map(({ description, title }) => {
+      // Match conventional commit pattern with named groups
+      const match = title.match( // eslint-disable-next-line @stylistic/max-len
+        /^(?<type>build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(?:\((?<scope>[^)]+)\))?(?<breaking>!)?: (?<description>.+)/,
+      )
+
+      if (!match?.groups) {
+        return {
+          breaking: false,
+          description: description || undefined,
+          title,
+          type: ChangeType.Unknown,
+        }
+      }
+
+      const { scope, type } = match.groups
+      const hasBreakingMarker = !!match.groups.breaking
+      const hasBreakingComment = title.includes('BREAKING CHANGE') || description.includes('BREAKING CHANGE')
+
+      return {
+        breaking: hasBreakingMarker || hasBreakingComment,
+        description: description || undefined,
+        scope,
+        title: match.groups.description,
+        type: type as ChangeType,
+      }
+    })
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Determines if a commit type should trigger a patch bump
+ * @param type - The commit type
+ * @returns Whether the commit type should trigger a patch bump
+ */
+export function isPatchChange(type: ChangeType): boolean {
+  return [
+    ChangeType.Chore,
+    ChangeType.Fix,
+    ChangeType.Refactor,
+    ChangeType.Revert,
+    ChangeType.Style,
+  ].includes(type)
+}
+
+/**
+ * Determines if a commit type should trigger a minor bump
+ * @param type - The commit type
+ * @returns Whether the commit type should trigger a minor bump
+ */
+export function isMinorChange(type: ChangeType): boolean {
+  return [
+    ChangeType.Feat,
+    ChangeType.Perf,
+  ].includes(type)
+}
+
+/**
+ * Determines if a commit type should not trigger any bump
+ * @param type - The commit type
+ * @returns Whether the commit type should not trigger any bump
+ */
+export function isNoChange(type: ChangeType): boolean {
+  return [
+    ChangeType.Build,
+    ChangeType.CI,
+    ChangeType.Docs,
+    ChangeType.Test,
+    ChangeType.Unknown,
+  ].includes(type)
+}


### PR DESCRIPTION
This pull request introduces significant changes to the release creation process by refactoring the GitHub action and implementing a new version determination logic using Bun. The most important changes are grouped into updates to the GitHub action configuration and the addition of new TypeScript files for version management.

### Updates to GitHub action configuration:
* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L12-R44): Replaced the `semver` step with a custom `version` step that uses Bun to determine the next version. Updated the steps to set up Bun and create the release using the `gh` CLI.

### Addition of new TypeScript files for version management:
* [`.github/actions/create-release/getNextVersion.ts`](diffhunk://#diff-206ba36aaedcd01f79849b5dacd2d796c1ef44322ec49938d65d7bc2746a929bR1-R97): Added a new script to determine the next version based on conventional commit messages. This script includes functions to parse and format versions, get the current version from the git repository, and determine the next version based on unreleased commits.
* [`.github/actions/create-release/getUnreleasedCommitMessages.ts`](diffhunk://#diff-d4b67875b7662e641c412753022c7ed1fbeededd605cf53ae79d9b355540af12R1-R132): Added a new script to fetch and parse unreleased commit messages. This script defines the `ChangeType` enum, the `ConventionalCommit` interface, and functions to get commit messages and determine if they should trigger version bumps.