### PR TITLE
ci: compare to latest release when in detached head state

### DIFF
--- a/libraries/workspaces/source/functions/getChangedFiles.ts
+++ b/libraries/workspaces/source/functions/getChangedFiles.ts
@@ -13,17 +13,18 @@ export async function getChangedFiles(
     await fetchAllTags()
     await $`git fetch origin ${base}:${base}`.quiet().nothrow()
 
-    // Check if we're on main branch
-    const currentBranch = await $`git branch --show-current`.quiet().text()
-    const isOnMain = currentBranch.trim() === 'main'
+    // Check if we're at the tip of the base branch
+    const baseRef = await $`git rev-parse origin/${base}`.quiet().text()
+    const headRef = await $`git rev-parse HEAD`.quiet().text()
+    const isAtBaseTip = baseRef.trim() === headRef.trim()
 
     let compareRef: string
-    if (isOnMain) {
-      // If we're on main, compare with the latest release tag
+    if (isAtBaseTip) {
+      // If we're at the tip, compare with the latest release tag
       const latestTag = await $`git describe --tags --abbrev=0`.quiet().nothrow().text().catch(() => '')
       compareRef = latestTag.trim() || 'HEAD~1' // Fallback to previous commit if no tags exist
     } else {
-      // If we're not on main, compare with main branch
+      // If we're not at the tip, compare with main branch
       compareRef = `origin/${base}`
     }
 


### PR DESCRIPTION
This pull request includes a change to the `getChangedFiles` function in `libraries/workspaces/source/functions/getChangedFiles.ts`. The update modifies the logic for determining the comparison reference when checking for changed files.

Key change:

* [`libraries/workspaces/source/functions/getChangedFiles.ts`](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L16-R27): Updated the logic to check if the current commit is at the tip of the base branch instead of checking if the current branch is 'main'. This change ensures that the comparison reference is determined accurately based on the commit position rather than the branch name.