### PR TITLE
ci: properly compute diff from tag on main

### DIFF
--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -38,8 +38,8 @@ export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[
   try {
     await $`git fetch --tags origin`.quiet()
 
-    // Get latest tag by version number
-    const latestTag = await $`git tag --sort=v:refname | tail -n 1`
+    // Get latest tag by version number (using proper semver sorting)
+    const latestTag = await $`git tag | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
 
     // If no tag exists, get all commits

--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -38,8 +38,9 @@ export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[
   try {
     await $`git fetch --tags origin`.quiet()
 
-    // Get the latest release tag
-    const latestTag = (await $`git describe --tags --abbrev=0`.text()).trim()
+    // Get latest tag by version number
+    const latestTag = await $`git tag --sort=v:refname | tail -n 1`
+      .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
 
     // If no tag exists, get all commits
     const range = latestTag

--- a/libraries/workspaces/source/functions/getChangedFiles.ts
+++ b/libraries/workspaces/source/functions/getChangedFiles.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { $ } from 'bun'
 import { fetchAllTags } from './fetchAllTags'
 
@@ -9,61 +8,29 @@ import { fetchAllTags } from './fetchAllTags'
  */
 export async function getChangedFiles(base = 'main'): Promise<string[]> {
   try {
-    console.log('\nChecking for changed files...')
-
     await fetchAllTags()
-    console.log('Fetched all tags')
-
     await $`git fetch origin ${base}:${base}`.quiet().nothrow()
-    console.log(`Fetched ${base} branch`)
 
-    // Log current git status
-    console.log('\nGit Status:')
-    console.log('Current SHA:', (await $`git rev-parse HEAD`.text()).trim())
-    console.log('Current branch:', (await $`git rev-parse --abbrev-ref HEAD`.text()).trim())
-
-    // Get all tags sorted by version
-    const tags = (await $`git tag -l`.text())
-      .trim()
-      .split('\n')
-      .filter(Boolean)
-      .sort((a, b) => {
-        const [aMajor, aMinor, aPatch] = a.replace('v', '').split('.').map(Number)
-        const [bMajor, bMinor, bPatch] = b.replace('v', '').split('.').map(Number)
-        return (bMajor - aMajor) || (bMinor - aMinor) || (bPatch - aPatch)
-      })
-
-    console.log('All tags:', tags.join(', '))
-    console.log('Tag count:', tags.length)
+    // Get latest tag by version number
+    const latestTag = await $`git tag --sort=v:refname | tail -n 1`
+      .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
 
     // Check if we're at the tip of the base branch
     const baseRef = await $`git rev-parse origin/${base}`.quiet().text()
     const headRef = await $`git rev-parse HEAD`.quiet().text()
     const isAtBaseTip = baseRef.trim() === headRef.trim()
 
-    console.log('\nRef Comparison:')
-    console.log(`Base ref (origin/${base}):`, baseRef.trim())
-    console.log('Head ref:', headRef.trim())
-    console.log('Is at base tip:', isAtBaseTip)
+    /*
+     * When on the base branch (e.g. main):
+     * - Compare against the latest tag if one exists
+     * - Fall back to previous commit only if no tags exist
+     * Otherwise compare against the base branch
+     */
+    const compareRef = isAtBaseTip
+      ? (latestTag || 'HEAD~1')
+      : `origin/${base}`
 
-    let compareRef: string
-    if (isAtBaseTip) {
-      /*
-       * If we're at the tip and have tags, compare with latest tag
-       * Otherwise fall back to previous commit
-       */
-      compareRef = tags.length > 0 ? tags[0] : 'HEAD~1'
-      console.log('\nOn base branch, comparing with:', compareRef)
-      if (compareRef === 'HEAD~1') {
-        console.log('Warning: No tags found, falling back to previous commit')
-      }
-    } else {
-      // If we're not at the tip, compare with main branch
-      compareRef = `origin/${base}`
-      console.log('\nNot on base branch, comparing with:', compareRef)
-    }
-
-    // Get changes between base and current branch
+    // Get all changes
     const committed = await $`git diff --name-only ${compareRef}..HEAD`
       .quiet().nothrow().text().then(t => t.split('\n')).catch(() => [])
     const staged = await $`git diff --name-only --cached`
@@ -71,23 +38,10 @@ export async function getChangedFiles(base = 'main'): Promise<string[]> {
     const unstaged = await $`git diff --name-only`
       .quiet().nothrow().text().then(t => t.split('\n')).catch(() => [])
 
-    console.log('\nFound changes:')
-    console.log('Committed:', committed.length)
-    console.log('Staged:', staged.length)
-    console.log('Unstaged:', unstaged.length)
-
-    const changes = [...new Set([...committed, ...staged, ...unstaged])]
+    return [...new Set([...committed, ...staged, ...unstaged])]
       .map(line => line.trim())
       .filter(Boolean)
-
-    console.log('\nTotal unique changes:', changes.length)
-    if (changes.length > 0) {
-      console.log('Changed files:', changes.join(', '))
-    }
-
-    return changes
-  } catch (error) {
-    console.error('\nError in getChangedFiles:', error)
+  } catch {
     return []
   }
 }

--- a/libraries/workspaces/source/functions/getChangedFiles.ts
+++ b/libraries/workspaces/source/functions/getChangedFiles.ts
@@ -11,8 +11,8 @@ export async function getChangedFiles(base = 'main'): Promise<string[]> {
     await fetchAllTags()
     await $`git fetch origin ${base}:${base}`.quiet().nothrow()
 
-    // Get latest tag by version number
-    const latestTag = await $`git tag --sort=v:refname | tail -n 1`
+    // Get latest tag by version number (using proper semver sorting)
+    const latestTag = await $`git tag | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
 
     // Check if we're at the tip of the base branch


### PR DESCRIPTION
This pull request includes significant changes to the `getUnreleasedCommitMessages` and `getChangedFiles` functions to improve their efficiency and readability. The most important changes include updating the method of fetching the latest tag, removing console logs, and refactoring the logic for determining the comparison reference for git changes.

Improvements to fetching the latest tag:

* [`.github/actions/create-release/getUnreleasedCommitMessages.ts`](diffhunk://#diff-d4b67875b7662e641c412753022c7ed1fbeededd605cf53ae79d9b355540af12L41-R43): Updated the method to fetch the latest tag by version number, ensuring it handles cases where no tags exist more gracefully.
* [`libraries/workspaces/source/functions/getChangedFiles.ts`](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L12-R44): Implemented a similar update to fetch the latest tag by version number.

Codebase simplification:

* [`libraries/workspaces/source/functions/getChangedFiles.ts`](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L1): Removed extensive console logging to clean up the code and improve performance.
* [`libraries/workspaces/source/functions/getChangedFiles.ts`](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L12-R44): Refactored the logic to determine the comparison reference when checking for changes, simplifying the decision-making process based on whether the current branch is at the tip of the base branch.