### PR TITLE
ci: pull tags correctly

### DIFF
--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -36,10 +36,10 @@ export interface ConventionalCommit {
  */
 export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[]> {
   try {
-    await $`git fetch --tags origin`.quiet()
+    await $`git fetch --tags --force origin`.quiet()
 
     // Get latest tag by version number (using proper semver sorting)
-    const latestTag = await $`git tag | sort -V | tail -n 1`
+    const latestTag = await $`git tag -l | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
 
     // If no tag exists, get all commits

--- a/libraries/workspaces/source/functions/fetchAllTags.ts
+++ b/libraries/workspaces/source/functions/fetchAllTags.ts
@@ -1,6 +1,8 @@
 import { $ } from 'bun'
 
-/** Fetch all tags from the origin repository */
+/**
+ * Fetch all tags from the remote repository
+ */
 export async function fetchAllTags(): Promise<void> {
-  await $`git fetch --tags origin`.quiet()
+  await $`git fetch --tags --force origin`.quiet()
 }

--- a/libraries/workspaces/source/functions/getChangedFiles.ts
+++ b/libraries/workspaces/source/functions/getChangedFiles.ts
@@ -12,7 +12,7 @@ export async function getChangedFiles(base = 'main'): Promise<string[]> {
     await $`git fetch origin ${base}:${base}`.quiet().nothrow()
 
     // Get latest tag by version number (using proper semver sorting)
-    const latestTag = await $`git tag | sort -V | tail -n 1`
+    const latestTag = await $`git tag -l | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
 
     // Check if we're at the tip of the base branch


### PR DESCRIPTION
This pull request includes changes to improve the reliability of fetching tags and commits from the remote repository. The most important changes include modifying the fetch commands to force update tags and adjusting the method for listing tags to ensure proper sorting.

Improvements to fetching tags and commits:

* [`.github/actions/create-release/getUnreleasedCommitMessages.ts`](diffhunk://#diff-d4b67875b7662e641c412753022c7ed1fbeededd605cf53ae79d9b355540af12L39-R42): Changed the fetch command to use `--force` and updated the tag listing command to use `git tag -l`.
* [`libraries/workspaces/source/functions/fetchAllTags.ts`](diffhunk://#diff-644c6632415dd3ab75e43874f66c15fa5e190d372e6fc823c5469e8d3ee21857L3-R7): Updated the fetch command to use `--force` for fetching tags from the remote repository.
* [`libraries/workspaces/source/functions/getChangedFiles.ts`](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L15-R15): Modified the tag listing command to use `git tag -l` for proper sorting.