### PR TITLE
ci: get revision for tag

### DIFF
--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -38,13 +38,13 @@ export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[
   try {
     await $`git fetch --tags --force origin`.quiet()
 
-    // Get latest tag by version number (using proper semver sorting)
+    // Get latest tag and its commit hash
     const latestTag = await $`git tag -l | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
 
     // If no tag exists, get all commits
     const range = latestTag
-      ? `${latestTag}..HEAD`
+      ? `$(git rev-list -n 1 ${latestTag})..HEAD`
       : 'HEAD'
 
     /*


### PR DESCRIPTION
This pull request includes changes to improve the handling of git tags and commit references in the `getUnreleasedCommitMessages` and `getChangedFiles` functions. The most important changes involve updating the logic to fetch and compare commit hashes more accurately.

Improvements to git tag handling:

* [`.github/actions/create-release/getUnreleasedCommitMessages.ts`](diffhunk://#diff-d4b67875b7662e641c412753022c7ed1fbeededd605cf53ae79d9b355540af12L41-R47): Updated the logic to fetch the latest tag and its commit hash for a more accurate commit range comparison.
* [`libraries/workspaces/source/functions/getChangedFiles.ts`](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L14-R14): Modified the logic to fetch the latest tag and its commit hash for comparison, ensuring accurate detection of changes.

Enhancements to commit reference comparison:

* [`libraries/workspaces/source/functions/getChangedFiles.ts`](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L23-R33): Refined the comparison logic to determine the correct reference point based on whether the current commit is at the tip of the base branch and whether a tag exists.