### PR TITLE
ci: properly get revision for tag

### DIFF
--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -41,10 +41,12 @@ export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[
     // Get latest tag and its commit hash
     const latestTag = await $`git tag -l | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
+    const latestTagCommit = await $`git rev-list -n 1 ${latestTag}`
+      .quiet().text().then(t => t.trim()).catch(() => '')
 
     // If no tag exists, get all commits
     const range = latestTag
-      ? `$(git rev-list -n 1 ${latestTag})..HEAD`
+      ? `${latestTagCommit}..HEAD`
       : 'HEAD'
 
     /*

--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -41,13 +41,16 @@ export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[
     // Get latest tag and its commit hash
     const latestTag = await $`git tag -l | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
-    const latestTagCommit = await $`git rev-list -n 1 ${latestTag}`
-      .quiet().text().then(t => t.trim()).catch(() => '')
 
-    // If no tag exists, get all commits
-    const range = latestTag
-      ? `${latestTagCommit}..HEAD`
-      : 'HEAD'
+    // Determine the range to check
+    let range: string
+    if (latestTag) {
+      const tagCommit = await $`git rev-list -n 1 ${latestTag}`
+        .quiet().nothrow().text().then(t => t.trim())
+      range = tagCommit ? `${tagCommit}..HEAD` : 'HEAD'
+    } else {
+      range = 'HEAD'
+    }
 
     /*
      * Get all commit messages since the last tag

--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { $ } from 'bun'
 
 /** The type of conventional commit */
@@ -36,21 +37,34 @@ export interface ConventionalCommit {
  */
 export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[]> {
   try {
+    console.log('Fetching tags...')
     await $`git fetch --tags --force origin`.quiet()
 
     // Get latest tag and its commit hash
     const latestTag = await $`git tag -l | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
+    console.log('Latest tag:', latestTag)
 
     // Determine the range to check
     let range: string
     if (latestTag) {
-      const tagCommit = await $`git rev-list -n 1 ${latestTag}`
+      const latestTagSHA = await $`git rev-list -n 1 ${latestTag}`
         .quiet().nothrow().text().then(t => t.trim())
-      range = tagCommit ? `${tagCommit}..HEAD` : 'HEAD'
+      console.log('Latest tag SHA:', latestTagSHA)
+
+      const headSHA = await $`git rev-parse HEAD`.quiet().text().then(t => t.trim())
+      console.log('HEAD SHA:', headSHA)
+
+      range = latestTagSHA ? `${latestTagSHA}..HEAD` : 'HEAD'
+      console.log('Using range:', range)
     } else {
       range = 'HEAD'
+      console.log('No tags found, using range:', range)
     }
+
+    // Log all commits in range
+    console.log('\nCommits in range:')
+    await $`git log ${range} --oneline`.quiet()
 
     /*
      * Get all commit messages since the last tag


### PR DESCRIPTION
This pull request includes improvements to the way the latest tag and its commit hash are retrieved for both unreleased commit messages and changed files. These changes ensure more accurate comparisons and enhance the reliability of the functions.

Improvements to tag retrieval and comparison:

* [`.github/actions/create-release/getUnreleasedCommitMessages.ts`](diffhunk://#diff-d4b67875b7662e641c412753022c7ed1fbeededd605cf53ae79d9b355540af12L41-R47): Updated the logic to fetch the latest tag and its commit hash, and used this commit hash for the comparison range.
* [`libraries/workspaces/source/functions/getChangedFiles.ts`](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L14-R14): Modified the logic to fetch the latest tag and its commit hash for comparison when determining changed files. [[1]](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L14-R14) [[2]](diffhunk://#diff-d7c98c857e069fc7a56f2b2bc42cb778b8514a5ed50464205b197d4fd5c761d8L23-R33)