### PR TITLE
ci: use an unshallow clone

### DIFF
--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -41,10 +41,12 @@ export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[
     // Get latest tag and its commit hash
     const latestTag = await $`git tag -l | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
+    const latestTagCommit = await $`git rev-list -n 1 ${latestTag}`
+      .quiet().text().then(t => t.trim()).catch(() => '')
 
     // If no tag exists, get all commits
     const range = latestTag
-      ? `$(git rev-list -n 1 ${latestTag})..HEAD`
+      ? `${latestTagCommit}..HEAD`
       : 'HEAD'
 
     /*

--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -37,7 +37,8 @@ export interface ConventionalCommit {
  */
 export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[]> {
   try {
-    console.log('Fetching tags...')
+    console.log('Fetching tags and history...')
+    await $`git fetch origin main:main`.quiet().nothrow()
     await $`git fetch --tags --force origin`.quiet()
 
     // Get latest tag and its commit hash

--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -41,13 +41,16 @@ export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[
     // Get latest tag and its commit hash
     const latestTag = await $`git tag -l | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
-    const latestTagCommit = await $`git rev-list -n 1 ${latestTag}`
-      .quiet().text().then(t => t.trim()).catch(() => '')
 
-    // If no tag exists, get all commits
-    const range = latestTag
-      ? `${latestTagCommit}..HEAD`
-      : 'HEAD'
+    // Determine the range to check
+    let range: string
+    if (latestTag) {
+      const tagCommit = await $`git rev-list -n 1 ${latestTag}`
+        .quiet().nothrow().text().then(t => t.trim())
+      range = tagCommit ? `${tagCommit}..HEAD` : 'HEAD'
+    } else {
+      range = 'HEAD'
+    }
 
     /*
      * Get all commit messages since the last tag

--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { $ } from 'bun'
 
 /** The type of conventional commit */
@@ -36,21 +37,34 @@ export interface ConventionalCommit {
  */
 export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[]> {
   try {
+    console.log('Fetching tags...')
     await $`git fetch --tags --force origin`.quiet()
 
     // Get latest tag and its commit hash
     const latestTag = await $`git tag -l | sort -V | tail -n 1`
       .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
+    console.log('Latest tag:', latestTag)
 
     // Determine the range to check
     let range: string
     if (latestTag) {
-      const tagCommit = await $`git rev-list -n 1 ${latestTag}`
+      const latestTagSHA = await $`git rev-list -n 1 ${latestTag}`
         .quiet().nothrow().text().then(t => t.trim())
-      range = tagCommit ? `${tagCommit}..HEAD` : 'HEAD'
+      console.log('Latest tag SHA:', latestTagSHA)
+
+      const headSHA = await $`git rev-parse HEAD`.quiet().text().then(t => t.trim())
+      console.log('HEAD SHA:', headSHA)
+
+      range = latestTagSHA ? `${latestTagSHA}..HEAD` : 'HEAD'
+      console.log('Using range:', range)
     } else {
       range = 'HEAD'
+      console.log('No tags found, using range:', range)
     }
+
+    // Log all commits in range
+    console.log('\nCommits in range:')
+    await $`git log ${range} --oneline`.quiet()
 
     /*
      * Get all commit messages since the last tag


### PR DESCRIPTION
This pull request includes a small change to the `getUnreleasedCommitMessages` function in the `.github/actions/create-release/getUnreleasedCommitMessages.ts` file. The change enhances the log message and adds a command to fetch the main branch.

* Enhanced log message to indicate fetching both tags and history.
* Added a command to fetch the main branch from the origin.