### PR TITLE
ci: properly compute git diff

### DIFF
--- a/.github/actions/create-release/getUnreleasedCommitMessages.ts
+++ b/.github/actions/create-release/getUnreleasedCommitMessages.ts
@@ -37,7 +37,10 @@ export interface ConventionalCommit {
  */
 export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[]> {
   try {
-    console.log('Fetching tags and history...')
+    console.log('Fetching full history and tags...')
+    // First unshallow the repository
+    await $`git fetch --unshallow origin`.quiet().nothrow()
+    // Then fetch main and tags
     await $`git fetch origin main:main`.quiet().nothrow()
     await $`git fetch --tags --force origin`.quiet()
 

--- a/libraries/workspaces/source/functions/fetchAllTags.ts
+++ b/libraries/workspaces/source/functions/fetchAllTags.ts
@@ -4,5 +4,6 @@ import { $ } from 'bun'
  * Fetch all tags from the remote repository
  */
 export async function fetchAllTags(): Promise<void> {
+  await $`git fetch --unshallow origin`.quiet().nothrow()
   await $`git fetch --tags --force origin`.quiet()
 }


### PR DESCRIPTION
This pull request includes changes to the process of fetching repository history and tags to ensure a complete history is obtained. The most important changes include updating the logging message and adding commands to unshallow the repository before fetching tags.

Improvements to fetching repository history and tags:

* [`.github/actions/create-release/getUnreleasedCommitMessages.ts`](diffhunk://#diff-d4b67875b7662e641c412753022c7ed1fbeededd605cf53ae79d9b355540af12L40-R43): Updated the logging message to indicate fetching the full history and added a command to unshallow the repository before fetching the main branch and tags.
* [`libraries/workspaces/source/functions/fetchAllTags.ts`](diffhunk://#diff-644c6632415dd3ab75e43874f66c15fa5e190d372e6fc823c5469e8d3ee21857R7): Added a command to unshallow the repository before fetching tags to ensure a complete history is obtained.