### PR TITLE
feat: remove unnecessary aliasing

### DIFF
--- a/libraries/react/components/Component/Component.tsx
+++ b/libraries/react/components/Component/Component.tsx
@@ -121,11 +121,11 @@ export abstract class Component<
    */
   render(): React.ReactNode {
     const Tag = this.tag
-    const { className, nodeRef: rootNodeRef } = this.props
+    const { className, nodeRef } = this.props
 
     return ( // @ts-expect-error - we are assuming a props match
       <Tag // @ts-expect-error - we are assuming a props match
-        ref={rootNodeRef}
+        ref={nodeRef}
         {...this.attributes}
         {...dataAttributes(this.data)}
         className={classNames(className, this.classNames)}


### PR DESCRIPTION
This pull request includes a small change to the `Component` class in the `libraries/react/components/Component/Component.tsx` file. The change renames a property from `rootNodeRef` to `nodeRef` for consistency and clarity.

* [`libraries/react/components/Component/Component.tsx`](diffhunk://#diff-dce6fa63b892e282579c347be4ff614160f57ba20cd65c25118f620363fd2a7fL124-R128): Renamed `rootNodeRef` to `nodeRef` in the `render` method.