### PR TITLE
ci: fix dependency ordering

### DIFF
--- a/.github/actions/create-release/README.md
+++ b/.github/actions/create-release/README.md
@@ -1,40 +1,43 @@
-# Create Convco Release
+# Create Release
 
 ## Purpose
 
-This action automates the process of creating a new release based on Conventional Commits. It handles versioning and changelog generation, ensuring that releases are consistent and well-documented. This is particularly useful for maintaining a clear project history and facilitating smooth deployments.
+This action creates a GitHub release with automatically generated release notes. It's designed to work in conjunction with the `determine-version` action, creating releases only when needed and with the correct version number.
 
 ## Inputs
 
-- **github-token**: GitHub token for creating the release. (Required)
+- **github-token**: GitHub token for creating the release (Required)
+- **version**: The version to release (Required)
 
 ## Usage Example
 ```yaml
-name: Create Release
-
-on:
-  push:
-    branches:
-      - main
-
 jobs:
-  create_release:
+  release:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      
+      # First determine if a release is needed
+      - name: Determine Version
+        id: version
+        uses: ./.github/actions/determine-version
 
-    - name: Create Release
-      uses: TroyAlford/basis/.github/actions/create-release@main
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      # Then create the release if needed
+      - name: Create Release
+        if: steps.version.outputs.release-needed == 'true'
+        uses: ./.github/actions/create-release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.version.outputs.next-version }}
 ```
 
-## Versioning
+## Release Notes
 
-Specify the versioning strategy for this action, if applicable.
+Release notes are automatically generated using GitHub's built-in release notes generation, which creates a changelog based on merged pull requests and their labels.
 
-## Contributing
+## Integration
 
-If you want to contribute to this action, please follow the contribution guidelines in the main repository.
+This action is typically used as part of a release workflow, alongside:
+- determine-version: To decide if a release is needed
+- Package publishing actions: To publish updated packages after release

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,5 +1,5 @@
 name: 'Create Release'
-description: 'Creates a new release based on conventional commits'
+description: 'Creates a new release if needed based on conventional commits'
 
 inputs:
   github-token:
@@ -7,38 +7,36 @@ inputs:
     required: true
 
 outputs:
+  current-version:
+    description: 'The current version before any release'
+    value: ${{ steps.version.outputs.current-version }}
   released:
     description: 'Whether a release was created'
-    value: ${{ steps.version.outputs.released }}
+    value: ${{ steps.version.outputs.release-needed }}
   version:
-    description: 'The version that was released'
-    value: ${{ steps.version.outputs.version }}
+    description: 'The version that was released (or current version if no release created)'
+    value: ${{ steps.version.outputs.next-version }}
 
 runs:
   using: "composite"
   steps:
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v1
-
-    - name: Setup Action
-      shell: bash
-      run: |
-        TEMP_DIR=$(mktemp -d)
-        cp ${{ github.action_path }}/*.ts "$TEMP_DIR/"
-        echo "ACTION_TEMP_DIR=$TEMP_DIR" >> $GITHUB_ENV
+    - uses: ./.github/actions/asdf-setup
 
     - name: Determine Next Version
       id: version
       shell: bash
-      run: bun run "$ACTION_TEMP_DIR/getNextVersion.ts"
+      run: |
+        TEMP_DIR=$(mktemp -d)
+        cp ${{ github.action_path }}/*.ts "$TEMP_DIR/"
+        bun run "$TEMP_DIR/getNextVersion.ts"
 
     - name: Create GitHub Release
-      if: steps.version.outputs.released == 'true'
+      if: steps.version.outputs.release-needed == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        version="${{ steps.version.outputs.version }}"
+        version="${{ steps.version.outputs.next-version }}"
         gh release create "$version" \
           --title "$version" \
           --generate-notes

--- a/.github/actions/create-release/getCurrentVersion.ts
+++ b/.github/actions/create-release/getCurrentVersion.ts
@@ -1,0 +1,13 @@
+import { $ } from 'bun'
+
+/**
+ * Get the current version from the git repository
+ * @returns The current version string (e.g. 'v1.2.3')
+ */
+export async function getCurrentVersion(): Promise<string> {
+  try {
+    return await $`git describe --tags --abbrev=0`.text().then(v => v.trim()) || 'v0.0.0'
+  } catch {
+    return 'v0.0.0'
+  }
+}

--- a/.github/actions/create-release/getNextVersion.ts
+++ b/.github/actions/create-release/getNextVersion.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { $ } from 'bun'
+import { getCurrentVersion } from './getCurrentVersion'
 import { getUnreleasedCommitMessages, isMinorChange, isPatchChange } from './getUnreleasedCommitMessages'
 
 /** A SemVer version */
@@ -14,8 +15,8 @@ interface Version {
 
 /**
  * Parse a version string into a Version object
- * @param version - The version string
- * @returns The parsed version
+ * @param version - The version string (e.g. 'v1.2.3')
+ * @returns The parsed version object
  */
 function parseVersion(version: string): Version {
   const [major = 0, minor = 0, patch = 0] = version
@@ -28,32 +29,22 @@ function parseVersion(version: string): Version {
 /**
  * Format a Version object into a version string
  * @param version - The Version object
- * @returns The formatted version string
+ * @returns The formatted version string (e.g. 'v1.2.3')
  */
 function formatVersion(version: Version): string {
   return `v${version.major}.${version.minor}.${version.patch}`
 }
 
-/**
- * Get the current version from the git repository
- * @returns The current version
- */
-async function getCurrentVersion(): Promise<string> {
-  try {
-    const { stdout } = await Bun.spawn(['git', 'describe', '--tags', '--abbrev=0'], {
-      stdout: 'pipe',
-    })
-    return new TextDecoder().decode(await stdout.getReader().read().then(r => r.value)) || 'v0.0.0'
-  } catch {
-    return 'v0.0.0'
-  }
-}
-
 /** Determine the next version based on the unreleased commit messages */
 async function main() {
+  const currentVersion = await getCurrentVersion()
+  await $`echo "current-version=${currentVersion}" >> $GITHUB_OUTPUT`
+
   const commits = await getUnreleasedCommitMessages()
   if (commits.length === 0) {
     console.log('No unreleased commits found')
+    await $`echo "release-needed=false" >> $GITHUB_OUTPUT`
+    await $`echo "next-version=${currentVersion}" >> $GITHUB_OUTPUT`
     process.exit(0)
   } else {
     console.log('Unreleased commits found:')
@@ -67,28 +58,28 @@ async function main() {
       .join('\n'))
   }
 
-  const currentVersion = await getCurrentVersion()
   const version = parseVersion(currentVersion)
+  let releaseNeeded = false
 
   // Check for breaking changes
   if (commits.some(commit => commit.breaking)) {
     version.major++
     version.minor = 0
     version.patch = 0
+    releaseNeeded = true
   } else if (commits.some(commit => isMinorChange(commit.type))) {
     version.minor++
     version.patch = 0
+    releaseNeeded = true
   } else if (commits.some(commit => isPatchChange(commit.type))) {
     version.patch++
   } else {
-    // No version bump needed
     console.log('No version bump needed')
-    process.exit(0)
   }
 
   const nextVersion = formatVersion(version)
-  await $`echo "version=${nextVersion}" >> $GITHUB_OUTPUT`
-  await $`echo "released=true" >> $GITHUB_OUTPUT`
+  await $`echo "release-needed=${releaseNeeded}" >> $GITHUB_OUTPUT`
+  await $`echo "next-version=${nextVersion}" >> $GITHUB_OUTPUT`
 }
 
 main().catch(error => {

--- a/.github/actions/determine-version/README.md
+++ b/.github/actions/determine-version/README.md
@@ -1,0 +1,49 @@
+# Determine Version
+
+## Purpose
+
+This action analyzes conventional commits to determine if a new version is needed and what that version should be. It's designed to be used as a prerequisite step before creating releases or publishing packages, ensuring consistent versioning across all release-related tasks.
+
+## Outputs
+
+- **release-needed**: Whether a new release should be created (`true`/`false`)
+- **current-version**: The current version from git tags (e.g. `v1.2.3`)
+- **next-version**: The computed next version (same as current if no release needed)
+
+## Usage Example
+```yaml
+jobs:
+  check_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Determine Version
+        id: version
+        uses: ./.github/actions/determine-version
+
+      # Use the outputs in subsequent steps
+      - name: Use Version Info
+        run: |
+          echo "Release needed: ${{ steps.version.outputs.release-needed }}"
+          echo "Current version: ${{ steps.version.outputs.current-version }}"
+          echo "Next version: ${{ steps.version.outputs.next-version }}"
+```
+
+## Version Calculation Rules
+
+Versions are calculated based on conventional commits since the last release:
+- Major version bump (breaking changes):
+  - Commits with `!` after the type
+  - Commits containing "BREAKING CHANGE" in title or body
+- Minor version bump:
+  - `feat`: New features
+  - `perf`: Performance improvements
+- Patch version bump:
+  - `fix`: Bug fixes
+  - `refactor`: Code refactoring
+  - `style`: Style changes
+  - `revert`: Reverted changes
+  - `chore`: Maintenance tasks
+
+Other commit types (`docs`, `test`, `ci`, `build`) don't trigger version bumps. 

--- a/.github/actions/determine-version/action.yml
+++ b/.github/actions/determine-version/action.yml
@@ -1,0 +1,25 @@
+name: 'Determine Version'
+description: 'Determines if a new release is needed based on conventional commits'
+
+outputs:
+  current-version:
+    description: 'The current version'
+    value: ${{ steps.version.outputs.current-version }}
+  next-version:
+    description: 'The next version (same as current if no release needed)'
+    value: ${{ steps.version.outputs.next-version }}
+  release-needed:
+    description: 'Whether a new release is needed'
+    value: ${{ steps.version.outputs.release-needed }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/asdf-setup
+    - name: Determine Version
+      id: version
+      shell: bash
+      run: |
+        TEMP_DIR=$(mktemp -d)
+        cp ${{ github.action_path }}/*.ts "$TEMP_DIR/"
+        bun run "$TEMP_DIR/determineVersion.ts"

--- a/.github/actions/determine-version/determineVersion.ts
+++ b/.github/actions/determine-version/determineVersion.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-console */
+import { $ } from 'bun'
+import { getCurrentVersion } from '../create-release/getCurrentVersion'
+import { getUnreleasedCommitMessages, isMinorChange, isPatchChange } from '../create-release/getUnreleasedCommitMessages'
+
+/** A semantic version number */
+interface Version {
+  /** The major version number, incremented for breaking changes */
+  major: number,
+  /** The minor version number, incremented for new features */
+  minor: number,
+  /** The patch version number, incremented for bug fixes */
+  patch: number,
+}
+
+/**
+ * Parse a version string into its component parts
+ * @param version - The version string to parse (e.g. 'v1.2.3')
+ * @returns A Version object containing the major, minor, and patch numbers
+ * @example
+ * parseVersion('v1.2.3') // { major: 1, minor: 2, patch: 3 }
+ * parseVersion('v0.0.0') // { major: 0, minor: 0, patch: 0 }
+ */
+function parseVersion(version: string): Version {
+  const [major = 0, minor = 0, patch = 0] = version
+    .replace(/^v/, '')
+    .split('.')
+    .map(Number)
+  return { major, minor, patch }
+}
+
+/**
+ * Format a Version object into a version string
+ * @param version - The Version object to format
+ * @returns A version string prefixed with 'v' (e.g. 'v1.2.3')
+ * @example
+ * formatVersion({ major: 1, minor: 2, patch: 3 }) // 'v1.2.3'
+ * formatVersion({ major: 0, minor: 0, patch: 0 }) // 'v0.0.0'
+ */
+function formatVersion(version: Version): string {
+  return `v${version.major}.${version.minor}.${version.patch}`
+}
+
+/**
+ * Determines if a new version is needed based on conventional commits, and if so, what that version should be.
+ * Outputs three GitHub Action variables:
+ * - current-version: The current version from git tags
+ * - next-version: The computed next version (same as current if no release needed)
+ * - release-needed: Whether a new release should be created
+ *
+ * Version numbers are incremented according to these rules:
+ * - Major version: Incremented for breaking changes
+ * - Minor version: Incremented for new features
+ * - Patch version: Incremented for bug fixes
+ *
+ * If no version bump is needed, next-version will equal current-version and release-needed will be false.
+ */
+async function main() {
+  const currentVersion = await getCurrentVersion()
+  await $`echo "current-version=${currentVersion}" >> $GITHUB_OUTPUT`
+
+  const commits = await getUnreleasedCommitMessages()
+  if (commits.length === 0) {
+    console.log('No unreleased commits found')
+    await $`echo "release-needed=false" >> $GITHUB_OUTPUT`
+    await $`echo "next-version=${currentVersion}" >> $GITHUB_OUTPUT`
+    process.exit(0)
+  }
+
+  console.log('Unreleased commits found:')
+  console.log(commits
+    .filter(commit => commit.title)
+    .map(commit => (
+      commit.title.length > 75
+        ? `${commit.type}: ${commit.title.slice(0, 75)}...`
+        : `${commit.type}: ${commit.title}`
+    ))
+    .join('\n'))
+
+  const version = parseVersion(currentVersion)
+  let releaseNeeded = false
+
+  // Determine version bump based on conventional commits
+  if (commits.some(commit => commit.breaking)) {
+    version.major++
+    version.minor = 0
+    version.patch = 0
+    releaseNeeded = true
+  } else if (commits.some(commit => isMinorChange(commit.type))) {
+    version.minor++
+    version.patch = 0
+    releaseNeeded = true
+  } else if (commits.some(commit => isPatchChange(commit.type))) {
+    version.patch++
+    releaseNeeded = true
+  }
+
+  const nextVersion = formatVersion(version)
+  await $`echo "release-needed=${releaseNeeded}" >> $GITHUB_OUTPUT`
+  await $`echo "next-version=${nextVersion}" >> $GITHUB_OUTPUT`
+}
+
+main().catch(error => {
+  console.error('Failed to determine version:', error)
+  process.exit(1)
+})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,42 +11,48 @@ permissions:
   pull-requests: write
 
 jobs:
-  release:
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      release-needed: ${{ steps.version.outputs.release-needed }}
+      next-version: ${{ steps.version.outputs.next-version }}
+      current-version: ${{ steps.version.outputs.current-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: ./.github/actions/asdf-setup
+      - name: Determine Version
+        id: version
+        uses: ./.github/actions/determine-version
+
+  create-release:
+    needs: determine-version
+    if: needs.determine-version.outputs.release-needed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: ./.github/actions/asdf-setup
+      - uses: ./.github/actions/create-release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ needs.determine-version.outputs.next-version }}
+
+  publish:
+    needs: determine-version
+    if: needs.determine-version.outputs.release-needed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: ./.github/actions/asdf-setup
 
-      - name: Create Release
-        id: create_release
-        uses: ./.github/actions/create-release
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check if Version Created
-        id: release_created
-        run: |
-          if [[ -n "${{ steps.create_release.outputs.released }}" ]]; then
-            echo "should_publish=true" >> $GITHUB_OUTPUT
-            echo "version=${{ steps.create_release.outputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "No new version created. Skipping publication."
-            echo "should_publish=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Identify Changed Workspaces
         id: changes
         run: |
-          changed=$(bun workspace changed)
-          echo "Changed workspaces: $changed"
-          echo "workspaces=$changed" >> $GITHUB_OUTPUT
-
-      - name: Publish Changed Workspaces to JSR
-        if: steps.changes.outputs.workspaces != '[]' && steps.release_created.outputs.should_publish == 'true'
-        run: |
-          workspaces='${{ steps.changes.outputs.workspaces }}'
-          version='${{ steps.release_created.outputs.version }}'
+          workspaces=$(bun workspace changed)
+          echo "Changed workspaces: $workspaces"
+          version='${{ needs.determine-version.outputs.next-version }}'
           
           # Prepare the --only flags for each workspace
           only_flags=$(echo "$workspaces" | jq -r '.[]' | sed 's/^/--only /')


### PR DESCRIPTION
This pull request includes significant changes to the release creation process and the introduction of a new action to determine if a release is needed. The most important changes include modifications to the `create-release` action, the addition of the `determine-version` action, and updates to the workflow to incorporate these changes.

### Changes to release creation process:

* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L2-R39): Updated descriptions and output values to reflect the new logic of determining if a release is needed. Replaced the setup step with a new action and adjusted the version determination logic.
* [`.github/actions/create-release/getNextVersion.ts`](diffhunk://#diff-206ba36aaedcd01f79849b5dacd2d796c1ef44322ec49938d65d7bc2746a929bR3): Refactored to use the new `getCurrentVersion` function and updated the logic to determine if a release is needed based on commit messages. [[1]](diffhunk://#diff-206ba36aaedcd01f79849b5dacd2d796c1ef44322ec49938d65d7bc2746a929bR3) [[2]](diffhunk://#diff-206ba36aaedcd01f79849b5dacd2d796c1ef44322ec49938d65d7bc2746a929bL17-R19) [[3]](diffhunk://#diff-206ba36aaedcd01f79849b5dacd2d796c1ef44322ec49938d65d7bc2746a929bL31-R47) [[4]](diffhunk://#diff-206ba36aaedcd01f79849b5dacd2d796c1ef44322ec49938d65d7bc2746a929bL70-R82)

### Introduction of `determine-version` action:

* [`.github/actions/determine-version/action.yml`](diffhunk://#diff-64f5056f156060043dc451631e5fcb4990061c3dfe978e9ea7f9e1a766e6d255R1-R25): Added a new action to determine if a new release is needed based on conventional commits.
* [`.github/actions/determine-version/determineVersion.ts`](diffhunk://#diff-109a4b4fd71b4c9b481e5684a6df0a3106084b47c79f376e34498a0112d3ba71R1-R106): Implemented the logic to determine the current version, check for unreleased commits, and decide if a new release is necessary.

### Workflow updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L14-R55): Split the release job into separate `determine-version`, `create-release`, and `publish` jobs, ensuring that the release and publish steps only run if a new release is needed.