### PR TITLE
feat: split up Router components into separate files with their own tests

### DIFF
--- a/libraries/react/components/Router/Link.test.tsx
+++ b/libraries/react/components/Router/Link.test.tsx
@@ -1,0 +1,52 @@
+import type { Mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import * as React from 'react'
+import { render } from '../../testing/render'
+import { Link } from './Link'
+
+describe('Link', () => {
+  let pushState: Mock<History['pushState']>
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'http://example.com/',
+        pathname: '/',
+        search: '',
+        toString() { return this.href },
+      },
+      writable: true,
+    })
+
+    pushState = spyOn(window.history, 'pushState').mockImplementation((state, title, url) => {
+      const [path, search] = url.toString().split('?')
+      window.location.pathname = path
+      window.location.search = search ? '?' + search : ''
+      window.location.href = 'http://example.com' + window.location.pathname + window.location.search
+    })
+  })
+
+  afterEach(() => {
+    pushState.mockRestore()
+  })
+
+  test('renders an anchor tag with the correct href', () => {
+    const { node } = render<Link>(
+      <Link to="/some/path">Click me</Link>,
+    )
+    expect(node.tagName).toBe('A')
+    expect(node.getAttribute('href')).toBe('/some/path')
+    expect(node.textContent).toBe('Click me')
+  })
+
+  test('uses pushState for client-side navigation', () => {
+    const { instance } = render<Link>(
+      <Link to="/new/path">Navigate</Link>,
+    )
+
+    const event = new MouseEvent('click')
+    instance.handleClick(event as unknown as React.MouseEvent<HTMLAnchorElement, MouseEvent>)
+
+    expect(pushState).toHaveBeenCalledTimes(1)
+  })
+})

--- a/libraries/react/components/Router/Link.tsx
+++ b/libraries/react/components/Router/Link.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+
+/** Props for the Link component */
+export interface LinkProps {
+  /** The content to render inside the link */
+  children: React.ReactNode,
+  /** The URL to navigate to */
+  to: string,
+}
+
+/**
+ * A component for client-side navigation between routes
+ */
+export class Link extends React.Component<LinkProps> {
+  /**
+   * Handles the click event
+   * @param event - The mouse event
+   */
+  handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    event.preventDefault()
+    window.history.pushState({}, '', this.props.to)
+  }
+
+  render() {
+    const { children, to } = this.props
+    return (
+      <a href={to} onClick={this.handleClick}>
+        {children}
+      </a>
+    )
+  }
+}

--- a/libraries/react/components/Router/Link.tsx
+++ b/libraries/react/components/Router/Link.tsx
@@ -1,27 +1,21 @@
 import * as React from 'react'
 
 /** Props for the Link component */
-export interface LinkProps {
+interface Props {
   /** The content to render inside the link */
   children: React.ReactNode,
   /** The URL to navigate to */
   to: string,
 }
 
-/**
- * A component for client-side navigation between routes
- */
-export class Link extends React.Component<LinkProps> {
-  /**
-   * Handles the click event
-   * @param event - The mouse event
-   */
-  handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+/** A component for client-side navigation between routes */
+export class Link extends React.Component<Props> {
+  handleClick: React.MouseEventHandler<HTMLAnchorElement> = event => {
     event.preventDefault()
     window.history.pushState({}, '', this.props.to)
   }
 
-  render() {
+  render(): React.ReactNode {
     const { children, to } = this.props
     return (
       <a href={to} onClick={this.handleClick}>

--- a/libraries/react/components/Router/Redirect.test.tsx
+++ b/libraries/react/components/Router/Redirect.test.tsx
@@ -1,0 +1,43 @@
+import type { Mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import * as React from 'react'
+import { render } from '../../testing/render'
+import { Redirect } from './Redirect'
+
+describe('Redirect', () => {
+  let replaceState: Mock<History['replaceState']>
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'http://example.com/',
+        pathname: '/',
+        search: '',
+        toString() { return this.href },
+      },
+      writable: true,
+    })
+
+    replaceState = spyOn(window.history, 'replaceState').mockImplementation((state, title, url) => {
+      const [path, search] = url.toString().split('?')
+      window.location.pathname = path
+      window.location.search = search ? '?' + search : ''
+      window.location.href = 'http://example.com' + window.location.pathname + window.location.search
+    })
+  })
+
+  afterEach(() => {
+    replaceState.mockRestore()
+  })
+
+  test('redirects to the specified path on mount', () => {
+    render<Redirect>(<Redirect to="/redirect/path" />)
+    expect(window.location.pathname).toBe('/redirect/path')
+    expect(replaceState).toHaveBeenCalledTimes(1)
+  })
+
+  test('renders nothing', () => {
+    const { node } = render<Redirect>(<Redirect to="/some/path" />)
+    expect(node).toBeNull()
+  })
+})

--- a/libraries/react/components/Router/Redirect.tsx
+++ b/libraries/react/components/Router/Redirect.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 /** Props for the Redirect component */
-export interface RedirectProps {
+interface Props {
   /** The URL to redirect to */
   to: string,
 }
@@ -9,13 +9,11 @@ export interface RedirectProps {
 /**
  * A component that performs a client-side redirect when mounted
  */
-export class Redirect extends React.Component<RedirectProps> {
+export class Redirect extends React.Component<Props> {
   componentDidMount(): void {
     const { to } = this.props
     window.history.replaceState({}, '', to)
   }
 
-  render() {
-    return null
-  }
+  render(): React.ReactNode { return null }
 }

--- a/libraries/react/components/Router/Redirect.tsx
+++ b/libraries/react/components/Router/Redirect.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+/** Props for the Redirect component */
+export interface RedirectProps {
+  /** The URL to redirect to */
+  to: string,
+}
+
+/**
+ * A component that performs a client-side redirect when mounted
+ */
+export class Redirect extends React.Component<RedirectProps> {
+  componentDidMount(): void {
+    const { to } = this.props
+    window.history.replaceState({}, '', to)
+  }
+
+  render() {
+    return null
+  }
+}

--- a/libraries/react/components/Router/Route.tsx
+++ b/libraries/react/components/Router/Route.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+/** Props for the Route component */
+export interface RouteProps<P = object> {
+  /** The children to render. Can be a function that receives route params, or a React node */
+  children: React.ReactNode | ((params: P) => React.ReactNode),
+  /** Whether to match the exact path */
+  exact?: boolean,
+  /** The URL to redirect to */
+  redirectTo?: string,
+  /** The template to match */
+  template: string,
+}
+
+/**
+ * A component for matching a route template against the current URL
+ * @template P The type of the route parameters
+ */
+export class Route<P> extends React.Component<RouteProps<P>> { }

--- a/libraries/react/components/Router/Route.tsx
+++ b/libraries/react/components/Router/Route.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 /** Props for the Route component */
-export interface RouteProps<P = object> {
+interface Props<P = object> {
   /** The children to render. Can be a function that receives route params, or a React node */
   children: React.ReactNode | ((params: P) => React.ReactNode),
   /** Whether to match the exact path */
@@ -16,4 +16,4 @@ export interface RouteProps<P = object> {
  * A component for matching a route template against the current URL
  * @template P The type of the route parameters
  */
-export class Route<P> extends React.Component<RouteProps<P>> { }
+export class Route<P> extends React.Component<Props<P>> { }

--- a/libraries/react/components/Router/Router.tsx
+++ b/libraries/react/components/Router/Router.tsx
@@ -3,7 +3,6 @@ import { parseTemplateURI } from '@basis/utilities'
 import { Component } from '../Component/Component'
 import { Link } from './Link'
 import { Redirect } from './Redirect'
-import type { RouteProps } from './Route'
 import { Route } from './Route'
 import { Switch } from './Switch'
 
@@ -84,7 +83,7 @@ export class Router extends Component<Props, null, State> {
     const route = React.Children.toArray(this.props.children).find(child => {
       if (!React.isValidElement(child) || child.type !== Router.Route) return false
       return !!parseTemplateURI(currentURL, child.props.template)
-    }) as React.ReactElement<RouteProps<unknown>> | undefined
+    }) as React.ReactElement<Route<unknown>['props']> | undefined
 
     if (route) {
       const { children, redirectTo, template } = route.props

--- a/libraries/react/components/Router/Router.tsx
+++ b/libraries/react/components/Router/Router.tsx
@@ -1,103 +1,43 @@
 import * as React from 'react'
 import { parseTemplateURI } from '@basis/utilities'
 import { Component } from '../Component/Component'
+import { Link } from './Link'
+import { Redirect } from './Redirect'
+import type { RouteProps } from './Route'
+import { Route } from './Route'
+import { Switch } from './Switch'
 
+/** Props for the Router component */
 interface Props {
-  /** The children to render. */
+  /** The routes to render */
   children: React.ReactNode,
 }
 
-interface RouteProps<P = object> {
-  /** The children to render. */
-  children: (params: P) => React.ReactNode | React.ReactNode,
-  /** Whether to match the exact path. */
-  exact?: boolean,
-  /** The URL to redirect to. */
-  redirectTo?: string,
-  /** The template to match. */
-  template: string,
-}
-
-interface LinkProps {
-  /** The children to render. */
-  children: React.ReactNode,
-  /** The URL to navigate to. */
-  to: string,
-}
-
-interface SwitchProps {
-  /** The children to render. */
-  children: React.ReactNode,
-}
-
-interface RedirectProps {
-  /** The URL to redirect to. */
-  to: string,
-}
-
+/** State for the Router component */
 interface State {
-  /** The current URL. */
+  /** The current URL */
   currentURL: string,
 }
 
-/** A component for routing between pages. */
+/**
+ * A component for client-side routing between pages
+ * @example
+ * <Router>
+ *   <Router.Switch>
+ *     <Router.Route template="/users/:id">
+ *       {params => <UserProfile id={params.id} />}
+ *     </Router.Route>
+ *     <Router.Route template="/">
+ *       <HomePage />
+ *     </Router.Route>
+ *   </Router.Switch>
+ * </Router>
+ */
 export class Router extends Component<Props, null, State> {
-  /** A component for matching a route. */
-  static Route: React.ComponentType<RouteProps<unknown>> = (
-    class Route<P> extends React.Component<RouteProps<P>> { }
-  )
-
-  /** A component for switching between routes. */
-  static Switch: React.ComponentType<SwitchProps> = (
-    class Switch extends React.Component<SwitchProps> {
-      render() {
-        const child = React.Children.toArray(this.props.children)
-          .find(c => React.isValidElement(c))
-        return (
-          <React.Fragment>
-            {child}
-          </React.Fragment>
-        )
-      }
-    }
-  )
-
-  /** A component for navigating to a URL. */
-  static Link: React.ComponentType<LinkProps> = (
-    class Link extends React.Component<LinkProps> {
-      /**
-       * Handles the click event.
-       * @param event - The mouse event.
-       */
-      handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-        event.preventDefault()
-        window.history.pushState({}, '', this.props.to)
-      }
-
-      render() {
-        const { children, to } = this.props
-        return (
-          <a href={to} onClick={this.handleClick}>
-            {children}
-          </a>
-        )
-      }
-    }
-  )
-
-  /** A component for redirecting to a URL. */
-  static Redirect: React.ComponentType<RedirectProps> = (
-    class Redirect extends React.Component<RedirectProps> {
-      componentDidMount(): void {
-        const { to } = this.props
-        window.history.replaceState({}, '', to)
-      }
-
-      render() {
-        return null
-      }
-    }
-  )
+  static Link = Link
+  static Route = Route
+  static Switch = Switch
+  static Redirect = Redirect
 
   state = {
     currentURL: window.location.pathname + window.location.search,
@@ -112,7 +52,7 @@ export class Router extends Component<Props, null, State> {
     window.removeEventListener('popstate', this.handleNavigate)
   }
 
-  /** Handles the navigation. */
+  /** Handles URL navigation */
   handleNavigate = (): void => {
     const newURL = window.location.pathname + window.location.search
     if (newURL !== this.state.currentURL) {
@@ -120,7 +60,7 @@ export class Router extends Component<Props, null, State> {
     }
   }
 
-  /** Patches the history methods. */
+  /** Patches history methods to trigger navigation handling */
   patchHistoryMethods = (): void => {
     const { pushState, replaceState } = window.history
 
@@ -136,8 +76,8 @@ export class Router extends Component<Props, null, State> {
   }
 
   /**
-   * Renders the route.
-   * @returns The rendered route.
+   * Renders the matching route
+   * @returns The rendered route or null if no match
    */
   renderRoute = (): React.ReactNode | null => {
     const { currentURL } = this.state

--- a/libraries/react/components/Router/Switch.test.tsx
+++ b/libraries/react/components/Router/Switch.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test'
+import * as React from 'react'
+import { render } from '../../testing/render'
+import { Switch } from './Switch'
+
+describe('Switch', () => {
+  test('renders only the first valid child', () => {
+    const { node } = render<Switch>(
+      <Switch>
+        <div>First</div>
+        <div>Second</div>
+        <div>Third</div>
+      </Switch>,
+    )
+    const firstChild = node.firstChild as HTMLElement
+    expect(firstChild.textContent).toBe('First')
+  })
+
+  test('handles no valid children', () => {
+    const { node } = render<Switch>(
+      <Switch>
+        {null}
+        {undefined}
+        {false}
+      </Switch>,
+    )
+    // When no valid children, the Fragment should still render but be empty
+    expect(node?.textContent ?? '').toBe('')
+  })
+})

--- a/libraries/react/components/Router/Switch.tsx
+++ b/libraries/react/components/Router/Switch.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 /** Props for the Switch component */
-export interface SwitchProps {
+interface Props {
   /** The routes to render. Only the first matching route will be rendered */
   children: React.ReactNode,
 }
@@ -9,8 +9,8 @@ export interface SwitchProps {
 /**
  * A component that renders only the first matching route from its children
  */
-export class Switch extends React.Component<SwitchProps> {
-  render() {
+export class Switch extends React.Component<Props> {
+  render(): React.ReactNode {
     const child = React.Children.toArray(this.props.children)
       .find(c => React.isValidElement(c))
     return (

--- a/libraries/react/components/Router/Switch.tsx
+++ b/libraries/react/components/Router/Switch.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+/** Props for the Switch component */
+export interface SwitchProps {
+  /** The routes to render. Only the first matching route will be rendered */
+  children: React.ReactNode,
+}
+
+/**
+ * A component that renders only the first matching route from its children
+ */
+export class Switch extends React.Component<SwitchProps> {
+  render() {
+    const child = React.Children.toArray(this.props.children)
+      .find(c => React.isValidElement(c))
+    return (
+      <React.Fragment>
+        {child}
+      </React.Fragment>
+    )
+  }
+}


### PR DESCRIPTION
This pull request introduces several new components and tests for the `Router` module in the `libraries/react/components` directory. The main changes include the addition of `Link`, `Redirect`, `Route`, and `Switch` components, as well as their corresponding tests. Additionally, the `Router` component has been refactored to integrate these new components.

New Components and Tests:

* `Link` component: A new component for client-side navigation between routes, along with tests to verify its functionality. [[1]](diffhunk://#diff-f85031758266c64fe0f005cbea8ca536e7df8048d06b4b92f456219a381624c4R1-R32) [[2]](diffhunk://#diff-29410eff3e9ab20cbaab9c88c8968a9e054d9ac059f3b6fb76efec94037f98b8R1-R52)

* `Redirect` component: A new component that performs a client-side redirect when mounted, with tests to ensure it redirects correctly and renders nothing. [[1]](diffhunk://#diff-4076dffd5bcaee3679370da09d05824c0e004bf76f05e9e975b9c997397144abR1-R21) [[2]](diffhunk://#diff-5e30d638332283147aa8b0ac171640870cd0e567853b3918ecd004d56d6e7032R1-R43)

* `Route` component: A new component for matching a route template against the current URL.

* `Switch` component: A new component that renders only the first matching route from its children, along with tests to verify its behavior. [[1]](diffhunk://#diff-036dd3182e604279d6ec3f39b059381292298daf27c66184f26330075a56d6b5R1-R22) [[2]](diffhunk://#diff-1c4a74995881697d0f5a2e521dd3f992c28c2060b0a755df0719b55b3e9a4a62R1-R30)

Refactoring of `Router` component:

* Integration of new components `Link`, `Redirect`, `Route`, and `Switch` into the `Router` component.

* Refactoring and simplification of existing route matching and navigation handling logic. [[1]](diffhunk://#diff-89fb074a84c92d8858fe91ef56a57c22426473476f4532cb91c3b8de3877ef67L115-R63) [[2]](diffhunk://#diff-89fb074a84c92d8858fe91ef56a57c22426473476f4532cb91c3b8de3877ef67L139-R80)

* Updates to `Router.test.tsx` to align with the new structure and functionality of the `Router` component. [[1]](diffhunk://#diff-604efb6fc4577adaa28bfe007162eb9ae35dd531eb75c53b5d5fec6ae39d36a1L42-R42) [[2]](diffhunk://#diff-604efb6fc4577adaa28bfe007162eb9ae35dd531eb75c53b5d5fec6ae39d36a1L52-R119)