### PR TITLE
ci: compute latest version bump

### DIFF
--- a/.github/actions/determine-version/getCurrentVersion.ts
+++ b/.github/actions/determine-version/getCurrentVersion.ts
@@ -1,13 +1,39 @@
 import { $ } from 'bun'
 
 /**
- * Get the current version from the git repository
+ * Get the current version from the git repository.
+ * This function will:
+ * 1. Unshallow the repository if needed
+ * 2. Fetch all tags
+ * 3. Return the latest version tag
  * @returns The current version string (e.g. 'v1.2.3')
  */
 export async function getCurrentVersion(): Promise<string> {
   try {
-    return await $`git describe --tags --abbrev=0`.text().then(v => v.trim()) || 'v0.0.0'
+    // First unshallow the repository
+    await $`git fetch --unshallow origin`.quiet().nothrow()
+    // Then fetch main and tags
+    await $`git fetch origin main:main`.quiet().nothrow()
+    await $`git fetch --tags --force origin`.quiet()
+
+    // Get latest tag, sorted by version number
+    const latestTag = await $`git tag -l | sort -V | tail -n 1`
+      .quiet().text().then(v => v.trim())
+
+    return latestTag || 'v0.0.0'
   } catch {
     return 'v0.0.0'
   }
+}
+
+/**
+ * Get the commit hash of the current version tag
+ * @returns The commit hash of the current version
+ */
+export async function getCurrentVersionCommit(): Promise<string> {
+  const currentVersion = await getCurrentVersion()
+  if (currentVersion === 'v0.0.0') return ''
+
+  return await $`git rev-list -n 1 ${currentVersion}`
+    .quiet().text().then(v => v.trim()).catch(() => '')
 }

--- a/.github/actions/determine-version/getUnreleasedCommitMessages.ts
+++ b/.github/actions/determine-version/getUnreleasedCommitMessages.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { $ } from 'bun'
+import { getCurrentVersion, getCurrentVersionCommit } from './getCurrentVersion'
 
 /** The type of conventional commit */
 export enum ChangeType {
@@ -37,23 +38,13 @@ export interface ConventionalCommit {
  */
 export async function getUnreleasedCommitMessages(): Promise<ConventionalCommit[]> {
   try {
-    console.log('Fetching full history and tags...')
-    // First unshallow the repository
-    await $`git fetch --unshallow origin`.quiet().nothrow()
-    // Then fetch main and tags
-    await $`git fetch origin main:main`.quiet().nothrow()
-    await $`git fetch --tags --force origin`.quiet()
-
-    // Get latest tag and its commit hash
-    const latestTag = await $`git tag -l | sort -V | tail -n 1`
-      .quiet().nothrow().text().then(t => t.trim()).catch(() => '')
+    const latestTag = await getCurrentVersion()
     console.log('Latest tag:', latestTag)
 
     // Determine the range to check
     let range: string
-    if (latestTag) {
-      const latestTagSHA = await $`git rev-list -n 1 ${latestTag}`
-        .quiet().nothrow().text().then(t => t.trim())
+    if (latestTag !== 'v0.0.0') {
+      const latestTagSHA = await getCurrentVersionCommit()
       console.log('Latest tag SHA:', latestTagSHA)
 
       const headSHA = await $`git rev-parse HEAD`.quiet().text().then(t => t.trim())


### PR DESCRIPTION
This pull request includes enhancements to the version determination process and refactoring to improve code reuse in the `.github/actions/determine-version` directory. The most important changes include updating the `getCurrentVersion` function, adding a new function to get the current version commit hash, and refactoring the `getUnreleasedCommitMessages` function to use these new utilities.

Enhancements to version determination:

* [`.github/actions/determine-version/getCurrentVersion.ts`](diffhunk://#diff-cdb49436a01124ea37f9f817ca52a264abf25a14fed7368cf752667ce66c71d7L4-R39): Updated the `getCurrentVersion` function to unshallow the repository, fetch all tags, and return the latest version tag. Added a new function `getCurrentVersionCommit` to get the commit hash of the current version tag.

Refactoring for code reuse:

* [`.github/actions/determine-version/getUnreleasedCommitMessages.ts`](diffhunk://#diff-b144a8558ee5cb9d6599f2126e0861f3edd1f924e1cf68635d6c1728627cd55cR3): Refactored the `getUnreleasedCommitMessages` function to use the `getCurrentVersion` and `getCurrentVersionCommit` functions, simplifying the process of fetching the latest tag and its commit hash. [[1]](diffhunk://#diff-b144a8558ee5cb9d6599f2126e0861f3edd1f924e1cf68635d6c1728627cd55cR3) [[2]](diffhunk://#diff-b144a8558ee5cb9d6599f2126e0861f3edd1f924e1cf68635d6c1728627cd55cL40-R47)