### PR TITLE
ci: add id-token: write to release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   packages: write
   pull-requests: write
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change adds the `id-token` permission with write access to the workflow configuration. This is required by the JSR OIDC publication workflow.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R10): Added `id-token` permission with write access.