### PR TITLE
ci: JSR needs no leading v on version #'s

### DIFF
--- a/.github/actions/determine-version/action.yml
+++ b/.github/actions/determine-version/action.yml
@@ -16,6 +16,7 @@ runs:
   using: "composite"
   steps:
     - uses: ./.github/actions/asdf-setup
+
     - name: Determine Version
       id: version
       shell: bash
@@ -23,3 +24,18 @@ runs:
         TEMP_DIR=$(mktemp -d)
         cp ${{ github.action_path }}/*.ts "$TEMP_DIR/"
         bun run "$TEMP_DIR/determineVersion.ts"
+
+    - name: Display Version Information
+      shell: bash
+      run: |
+        echo "📦 Version Information"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "🏷️  Current version: ${{ steps.version.outputs.current-version }}"
+        if [[ "${{ steps.version.outputs.release-needed }}" == "true" ]]; then
+          echo "🚀 Release needed: Yes"
+          echo "⬆️  Bumping from ${{ steps.version.outputs.current-version }} → ${{ steps.version.outputs.next-version }}"
+        else
+          echo "✨ Release needed: No"
+          echo "💫 Staying at ${{ steps.version.outputs.current-version }}"
+        fi
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,12 @@ jobs:
         run: |
           workspaces=$(bun workspace changed)
           echo "Changed workspaces: $workspaces"
-          version='${{ needs.determine-version.outputs.next-version }}'
+          version='${${{ needs.determine-version.outputs.next-version }}#v}'
           
           # Prepare the --only flags for each workspace
           only_flags=$(echo "$workspaces" | jq -r '.[]' | sed 's/^/--only /')
           
-          echo "Publishing workspaces to JSR"
+          echo "Publishing workspaces to JSR as version $version"
           bun ws publish --version "$version" $only_flags || {
             echo "::error::Failed to publish workspaces to JSR"
             exit 1


### PR DESCRIPTION
This pull request includes changes to improve the version determination and display process in the GitHub Actions workflow, as well as a minor fix in the release workflow.

Enhancements to version determination and display:

* [`.github/actions/determine-version/action.yml`](diffhunk://#diff-64f5056f156060043dc451631e5fcb4990061c3dfe978e9ea7f9e1a766e6d255R19-R41): Added a new step to display version information, including whether a release is needed and the current and next version numbers.

Fixes in the release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L56-R61): Corrected the syntax for extracting the next version from the `determine-version` output to ensure it is properly formatted.