### PR TITLE
feat: improve Carousel

### DIFF
--- a/libraries/react/components/Carousel/Carousel.scss
+++ b/libraries/react/components/Carousel/Carousel.scss
@@ -1,151 +1,186 @@
 .carousel.component {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  isolation: isolate;
+  justify-content: center;
+  overflow: hidden;
   position: relative;
   width: 100%;
-  height: 100%;
-  overflow: hidden;
-  display: flex;
-  isolation: isolate;
 
   > img {
-    transition: transform 0.3s ease;
     cursor: pointer;
+    transition: transform 0.3s ease;
   }
 
-  &[data-size="contain"] {
-    > img {
-      max-width: 100%;
-      max-height: 100%;
-      width: auto;
-      height: auto;
-      object-fit: contain;
+  > .navigation {
+    align-items: center;
+    bottom: 1rem;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    left: 50%;
+    opacity: 0;
+    position: absolute;
+    transform: translateX(-50%);
+    transition: opacity 0.2s ease;
+    z-index: 1;
+
+    > button, > .counter {
+      align-items: center;
+      background: rgba(0, 0, 0, 0.5);
+      border: none;
+      border-radius: 1rem;
+      color: white;
+      display: inline-flex;
+      font-size: 0.875rem;
+      height: 2rem;
+      justify-content: center;
+      line-height: 1;
+      padding: 0 0.75rem;
+      transition: background 0.2s;
     }
 
-    &[data-align="nw"] > img { margin: 0 auto auto 0; }
-    &[data-align="n"] > img { margin: 0 auto auto auto; }
-    &[data-align="ne"] > img { margin: 0 0 auto auto; }
-    &[data-align="e"] > img { margin: auto 0 auto auto; }
-    &[data-align="se"] > img { margin: auto 0 0 auto; }
-    &[data-align="s"] > img { margin: auto auto 0 auto; }
-    &[data-align="sw"] > img { margin: auto auto 0 0; }
-    &[data-align="w"] > img { margin: auto 0 auto 0; }
-    &[data-align="center"] > img { margin: auto; }
-  }
+    > button {
+      cursor: pointer;
+      min-width: 2rem;
 
-  &[data-size="fill"] {
-    > img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
+      &:hover {
+        background: rgba(0, 0, 0, 0.8);
+      }
+
+      &:focus {
+        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
+        outline: none;
+      }
     }
 
-    &[data-align="nw"] > img { object-position: left top; }
-    &[data-align="n"] > img { object-position: center top; }
-    &[data-align="ne"] > img { object-position: right top; }
-    &[data-align="e"] > img { object-position: right center; }
-    &[data-align="se"] > img { object-position: right bottom; }
-    &[data-align="s"] > img { object-position: center bottom; }
-    &[data-align="sw"] > img { object-position: left bottom; }
-    &[data-align="w"] > img { object-position: left center; }
-    &[data-align="center"] > img { object-position: center center; }
+    > .counter {
+      white-space: nowrap;
+    }
   }
 
-  > .lightbox-overlay {
+  // Show navigation on hover or when carousel has focus
+  &:hover > .navigation,
+  &:focus > .navigation,
+  &:focus-within > .navigation {
+    opacity: 1;
+  }
+
+  &[data-size="contain"] > img {
+    height: auto;
+    max-height: 100%;
+    max-width: 100%;
+    object-fit: contain;
+    width: auto;
+  }
+
+  &[data-size="fill"] > img {
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+  }
+
+  // Alignment modifiers for contain mode
+  &[data-size="contain"][data-align="nw"] > img { margin: 0 auto auto 0; }
+  &[data-size="contain"][data-align="n"] > img { margin: 0 auto auto auto; }
+  &[data-size="contain"][data-align="ne"] > img { margin: 0 0 auto auto; }
+  &[data-size="contain"][data-align="e"] > img { margin: auto 0 auto auto; }
+  &[data-size="contain"][data-align="se"] > img { margin: auto 0 0 auto; }
+  &[data-size="contain"][data-align="s"] > img { margin: auto auto 0 auto; }
+  &[data-size="contain"][data-align="sw"] > img { margin: auto auto 0 0; }
+  &[data-size="contain"][data-align="w"] > img { margin: auto 0 auto 0; }
+  &[data-size="contain"][data-align="center"] > img { margin: auto; }
+
+  // Alignment modifiers for fill mode
+  &[data-size="fill"][data-align="nw"] > img { object-position: left top; }
+  &[data-size="fill"][data-align="n"] > img { object-position: center top; }
+  &[data-size="fill"][data-align="ne"] > img { object-position: right top; }
+  &[data-size="fill"][data-align="e"] > img { object-position: right center; }
+  &[data-size="fill"][data-align="se"] > img { object-position: right bottom; }
+  &[data-size="fill"][data-align="s"] > img { object-position: center bottom; }
+  &[data-size="fill"][data-align="sw"] > img { object-position: left bottom; }
+  &[data-size="fill"][data-align="w"] > img { object-position: left center; }
+  &[data-size="fill"][data-align="center"] > img { object-position: center center; }
+
+  &.lightbox {
     align-items: center;
     background: rgba(0, 0, 0, 0.9);
+    bottom: 0;
     display: flex;
-    height: 100vh;
     justify-content: center;
     left: 0;
     position: fixed;
+    right: 0;
     top: 0;
-    width: 100vw;
 
-    > img {
+    > .close-button {
+      align-items: center;
+      background: rgba(0, 0, 0, 0.5);
+      border-radius: 50%;
+      border: none;
+      color: white;
       cursor: pointer;
-      height: auto;
-      max-height: min(100%, 100vh);
-      max-width: min(100%, 100vw);
-      object-fit: contain;
-      transition: transform 0.3s ease;
-      width: auto;
+      display: flex;
+      font-size: 1.5rem;
+      height: 2.5rem;
+      justify-content: center;
+      position: fixed;
+      right: 1rem;
+      top: 1rem;
+      transition: background 0.2s;
+      width: 2.5rem;
+      z-index: 2;
+
+      &:hover {
+        background: rgba(0, 0, 0, 0.8);
+      }
+
+      &:focus {
+        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
+        outline: none;
+      }
     }
 
-    &[data-full-size="true"] > img {
-      height: 100%;
-      max-height: none;
-      max-width: none;
-      width: 100%;
+    > .image-container {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      max-height: 100vh;
+      max-width: 100%;
+      position: relative;
+
+      > img {
+        cursor: pointer;
+        height: auto;
+        max-height: min(100%, 100vh);
+        max-width: min(100%, 100vw);
+        object-fit: contain;
+        transition: transform 0.3s ease;
+        width: auto;
+      }
     }
 
     > .navigation {
-      bottom: 0;
-      left: 0;
-      pointer-events: none;
-      position: absolute;
-      right: 0;
-      top: 0;
-
-      > .prev, > .next {
-        bottom: 0;
-        cursor: pointer;
-        opacity: 0;
-        pointer-events: auto;
-        position: absolute;
-        top: 0;
-        transition: opacity 0.2s;
-        width: 30%;
-
-        &:hover {
-          opacity: 1;
-          background: linear-gradient(90deg, 
-            rgba(255,255,255,0.15) 0%, 
-            rgba(255,255,255,0.1) 25%,
-            rgba(255,255,255,0.05) 50%,
-            rgba(255,255,255,0.02) 75%,
-            rgba(255,255,255,0) 100%
-          );
-        }
-      }
-
-      > .prev { left: 0; }
-      > .next { 
-        right: 0;
-        transform: rotate(180deg);
-      }
-    }
-
-    > .indicators {
-      bottom: 1rem;
-      display: flex;
-      gap: 0.5rem;
-      left: 50%;
-      position: absolute;
-      transform: translateX(-50%);
-
-      > .dot {
-        background: rgba(255,255,255,0.5);
-        border-radius: 50%;
-        height: 8px;
-        width: 8px;
-
-        &[data-active="true"] {
-          background: white;
-        }
-      }
+      bottom: 2rem;
+      opacity: 1;  // Always visible in lightbox mode
     }
 
     > .lightbox-caption {
       background: rgba(0, 0, 0, 0.5);
       border-radius: 4px;
-      bottom: 2.5rem;
+      bottom: 5rem;
       color: white;
       font-size: 1rem;
       left: 50%;
       line-height: 1.5;
+      max-width: 80%;
       padding: 0.5rem 1rem;
       position: absolute;
       text-align: center;
       transform: translateX(-50%);
+      white-space: normal;
+      z-index: 1;
     }
   }
 } 

--- a/libraries/react/components/Image/Image.tsx
+++ b/libraries/react/components/Image/Image.tsx
@@ -12,6 +12,8 @@ interface Props {
   alt?: string,
   /** Click handler. */
   onClick?: (event: React.MouseEvent<HTMLImageElement>) => void,
+  /** Mouse down handler. */
+  onMouseDown?: (event: React.MouseEvent<HTMLImageElement>) => void,
   /** Touch end handler. */
   onTouchEnd?: (event: React.TouchEvent<HTMLImageElement>) => void,
   /** Touch move handler. */
@@ -61,6 +63,7 @@ export class Image extends Component<Props, HTMLImageElement, State> {
     return {
       alt: this.props.alt || '',
       onClick: this.props.onClick,
+      onMouseDown: this.props.onMouseDown,
       onTouchEnd: this.props.onTouchEnd,
       onTouchMove: this.props.onTouchMove,
       onTouchStart: this.props.onTouchStart,


### PR DESCRIPTION
This pull request includes significant updates to the `Carousel` component, focusing on enhancing its functionality and improving the codebase. The changes include modifications to the component's styles, tests, and TypeScript definitions.

### Style Improvements:
* [`libraries/react/components/Carousel/Carousel.scss`](diffhunk://#diff-5fc53dd2881f1bcfea8da45878bd81854b6d4ef2717124d28e03e7cf292e1d7aL2-R183): Refactored the CSS to improve the layout and visibility of navigation elements, added hover and focus states for better user interaction, and restructured the alignment and size modifiers for images.

### Test Enhancements:
* [`libraries/react/components/Carousel/Carousel.test.tsx`](diffhunk://#diff-8dad8f4b85517db92d6a9ca8d437babdb133e61f605047eb6cf4ff43cae2da0fL105-L215): Updated tests to handle new interactions such as closing the lightbox with the escape key, responding to arrow keys when focused, and opening images in a new tab on middle-click. Removed redundant tests and added new ones for mouse and touch interactions. [[1]](diffhunk://#diff-8dad8f4b85517db92d6a9ca8d437babdb133e61f605047eb6cf4ff43cae2da0fL105-L215) [[2]](diffhunk://#diff-8dad8f4b85517db92d6a9ca8d437babdb133e61f605047eb6cf4ff43cae2da0fL224-R226)

### Codebase Simplification:
* [`libraries/react/components/Carousel/Carousel.tsx`](diffhunk://#diff-b4f47a4e1255f01f2fceedb17f469e9bd95d71d104ca763e3ea06ed4cb060c59R2): Simplified the state management by removing the `fullSize` state and consolidating the `data` and `attributes` getters. Added the `createPortal` import to support rendering elements outside the main DOM hierarchy. [[1]](diffhunk://#diff-b4f47a4e1255f01f2fceedb17f469e9bd95d71d104ca763e3ea06ed4cb060c59R2) [[2]](diffhunk://#diff-b4f47a4e1255f01f2fceedb17f469e9bd95d71d104ca763e3ea06ed4cb060c59L31-L32) [[3]](diffhunk://#diff-b4f47a4e1255f01f2fceedb17f469e9bd95d71d104ca763e3ea06ed4cb060c59L67) [[4]](diffhunk://#diff-b4f47a4e1255f01f2fceedb17f469e9bd95d71d104ca763e3ea06ed4cb060c59L76-R85) [[5]](diffhunk://#diff-b4f47a4e1255f01f2fceedb17f469e9bd95d71d104ca763e3ea06ed4cb060c59R95-R114)