### PR TITLE
fix: less plugin support for javascript and node_modules resolution

### DIFF
--- a/libraries/bun-plugins/source/pluginLESS.ts
+++ b/libraries/bun-plugins/source/pluginLESS.ts
@@ -42,6 +42,8 @@ export function pluginLESS(options: PluginLESSOptions = {}): BunPlugin {
         const result = await less.render(source, {
           compress: minify,
           filename: args.path,
+          javascriptEnabled: true,
+          paths: [path.resolve(process.cwd(), 'node_modules')],
         })
 
         return {


### PR DESCRIPTION
Improve `pluginLESS` so that it supports javascript `LESS` functionality and properly resolves `node_modules` imports.