### PR TITLE
fix: Editor should output data-field if field prop is set

### DIFF
--- a/libraries/react/components/Editor/Editor.test.tsx
+++ b/libraries/react/components/Editor/Editor.test.tsx
@@ -43,15 +43,28 @@ describe('Editor', () => {
     test('renders with field identifier', async () => {
       const { node: numberNode } = await render(<TestEditor field="1" />)
       expect(numberNode).toHaveClass('editor', '1')
+      expect(numberNode).toHaveAttribute('data-field', '1')
 
       const { node: stringNode } = await render(<TestEditor field="test-field" />)
       expect(stringNode).toHaveClass('editor', 'test-field')
+      expect(stringNode).toHaveAttribute('data-field', 'test-field')
+    })
+
+    test('renders without data-field when field is not provided', async () => {
+      const { node } = await render(<TestEditor />)
+      expect(node).not.toHaveAttribute('data-field')
     })
 
     test('renders with read-only state', async () => {
       const { node } = await render(<TestEditor readOnly />)
       expect(node).toHaveAttribute('readOnly')
       expect(node).toHaveAttribute('aria-readonly', 'true')
+    })
+
+    test('renders without readOnly attribute when not read-only', async () => {
+      const { node } = await render(<TestEditor />)
+      expect(node).not.toHaveAttribute('readOnly')
+      expect(node).toHaveAttribute('aria-readonly', 'false')
     })
   })
 

--- a/libraries/react/components/Editor/Editor.tsx
+++ b/libraries/react/components/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import { clone, deepEquals, noop, set } from '@basis/utilities'
+import { clone, deepEquals, isNil, noop, set } from '@basis/utilities'
 import { Component } from '../Component/Component'
 
 interface TProps<Value> {
@@ -82,7 +82,8 @@ export abstract class Editor<
   get attributes(): (typeof this)['attributes'] {
     return {
       ...super.attributes,
-      readOnly: this.props.readOnly ? 'readOnly' : undefined,
+      'data-field': isNil(this.props.field) ? undefined : this.props.field,
+      'readOnly': this.props.readOnly ? 'readOnly' : undefined,
     }
   }
 


### PR DESCRIPTION
Editor should output `data-field` if `field` prop is set.