### PR TITLE
fix: Editor's readOnly should receive children

### DIFF
--- a/libraries/react/components/Editor/Editor.tsx
+++ b/libraries/react/components/Editor/Editor.tsx
@@ -150,7 +150,7 @@ export abstract class Editor<
   content(children?: React.ReactNode): React.ReactNode {
     return super.content(
       (this.props.readOnly && typeof this.readOnly === 'function')
-        ? this.readOnly()
+        ? this.readOnly(children)
         : children,
     )
   }


### PR DESCRIPTION
The Editor's readOnly method should receive children as a parameter to allow read-only components to access and potentially modify the children content. This enables read-only editors to properly handle their child components while maintaining the read-only state.