### PR TITLE
feat(table): add Column.DateTime column type

### DIFF
--- a/.claude/skills/branch-and-pr.md
+++ b/.claude/skills/branch-and-pr.md
@@ -1,0 +1,68 @@
+# branch-and-pr
+
+Use this skill when asked to create a branch, commit, or pull request.
+
+## Convco Commit Types
+
+| Type | Use for |
+|---|---|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Code change that is neither a fix nor a feature |
+| `test` | Adding or correcting tests |
+| `docs` | Documentation only |
+| `chore` | Build process, dependencies, tooling |
+| `perf` | Performance improvement |
+| `ci` | CI/CD changes |
+
+## Branch Names
+
+Format: `{type}/{short-kebab-description}`
+
+Examples:
+- `feat/db-backup-and-restore`
+- `fix/backup-dir-permissions`
+- `refactor/schema-bootstrap-phases`
+
+## Commit Messages
+
+Format: `{type}({scope}): {short description}`
+
+- Scope is optional but preferred when the change is clearly scoped to one area
+- Description is lowercase, imperative mood, no trailing period
+- Body is optional; use it only for non-obvious context
+
+Examples:
+- `feat(db): add pg_dump backup and restore via docker exec`
+- `fix(backup): use relative path for BACKUP_DIR default`
+- `refactor(schema): split bootstrap into extensions/tables/views phases`
+
+## Pull Request Titles
+
+Same format as commit messages: `{type}({scope}): {short description}`
+
+## Pull Request Bodies
+
+- **Terse and focused** — what changed and why, not how
+- Use a short bullet list for the summary (3–5 bullets max)
+- No implementation details, no code walkthroughs
+- Include a test plan checklist
+
+Template:
+```
+## Summary
+- {what changed, one line per logical unit}
+- {why it was needed or what problem it solves}
+
+## Test plan
+- [ ] {key thing to verify manually or via tests}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## Workflow
+
+1. Determine the convco type and scope from the changes
+2. Create the branch: `git checkout -b {type}/{description}`
+3. Stage and commit with a convco message
+4. Push and open the PR with a convco title and terse body

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Agent instructions
+
+Guidance for humans and coding agents working in this repository.
+
+## Documentation
+
+- **Keep docs in the same change as the code.** Whenever you add or change public API surface, default behavior, or user-visible component behavior, update the matching documentation page under `libraries/docs/pages/` (files named `*.docs.tsx`).
+- **What counts:** new or renamed props, enum values, column types, static helpers on components, sorting or alignment rules, and similar contract changes.
+- **Goal:** A reader browsing the docs app should see the current behavior without relying on the PR description alone.
+
+## Commits
+
+- **Do not skip repository checks** when committing (for example `--no-verify` or other flags that bypass Husky). Let lint, typecheck, and tests run; fix failures instead of silencing hooks.
+
+## CI and releases
+
+- **Pull requests** to `main` run `.github/workflows/ci.yml` (ESLint, tests, TypeScript). That workflow must pass before merge.
+- **After merge to `main`**, `.github/workflows/release.yml` runs. It determines the next semantic version and creates a GitHub release and tag. Downstream repos (for example consumers pinning `github:…/basis#v…`) should use that tag.

--- a/libraries/docs/pages/Table.docs.tsx
+++ b/libraries/docs/pages/Table.docs.tsx
@@ -14,6 +14,7 @@ interface User {
   givenName: string,
   id: number,
   lastLogin: string,
+  lastUpdated: string,
   name: string,
   profile: {
     avatar: string,
@@ -38,6 +39,7 @@ export class TableDocs extends Documentation<Record<string, never>> {
         givenName,
         id: i + 1,
         lastLogin: faker.date.recent({ days: 30 }).toISOString(),
+        lastUpdated: faker.date.recent({ days: 7 }).toISOString(),
         name: `${givenName} ${familyName}`,
         profile: {
           avatar: faker.image.avatar(),
@@ -95,13 +97,17 @@ export class TableDocs extends Documentation<Record<string, never>> {
         </Section>
         <Section title="Column Types">
           <p>
-            The Table component supports five built-in column types, each optimized for different data types:
+            The Table component supports six built-in column types, each optimized for different data types:
           </p>
           <ul>
             <li><strong>Text</strong> - For string data, renders as TextEditor</li>
             <li><strong>Number</strong> - For numeric data, renders as NumberEditor</li>
-            <li><strong>Boolean</strong> - For boolean data, renders as ToggleEditor</li>
-            <li><strong>Date</strong> - For date data, displays formatted dates</li>
+            <li><strong>Boolean</strong> - For boolean data, renders as CheckboxEditor</li>
+            <li><strong>Date</strong> - For date-only values, displays a formatted date</li>
+            <li>
+              <strong>DateTime</strong> - For date-and-time values, displays a medium date and short time via{' '}
+              <code>toLocaleString</code>
+            </li>
             <li><strong>Enum</strong> - For enumerated values, renders as EnumEditor with dropdown</li>
           </ul>
           <p>
@@ -109,8 +115,8 @@ export class TableDocs extends Documentation<Record<string, never>> {
           </p>
           <ul>
             <li>Text and Enum columns sort by name/label and are left-aligned</li>
-            <li>Number, Boolean, and Date columns sort by value</li>
-            <li>Numbers are right-aligned, Booleans and Dates are center-aligned</li>
+            <li>Number, Boolean, Date, and DateTime columns sort by value</li>
+            <li>Numbers are right-aligned; Booleans, Dates, and DateTimes are center-aligned</li>
           </ul>
         </Section>
         <Section title="Nested Data Access">
@@ -176,7 +182,7 @@ export class TableDocs extends Documentation<Record<string, never>> {
           <ul>
             <li><strong>Text/Enum</strong>: Left-aligned</li>
             <li><strong>Number</strong>: Right-aligned</li>
-            <li><strong>Boolean/Date</strong>: Center-aligned</li>
+            <li><strong>Boolean/Date/DateTime</strong>: Center-aligned</li>
           </ul>
           <h4>Row Interactions</h4>
           <p>
@@ -231,7 +237,7 @@ export class TableDocs extends Documentation<Record<string, never>> {
             <li><code>pin?: Pin</code> - Column pinning position (Left, Right, Unpinned)</li>
             <li><code>sortable?: boolean</code> - Whether the column is sortable (default: true)</li>
             <li><code>title?: string</code> - Column header text (defaults to field name)</li>
-            <li><code>type?: ColumnType</code> - Column type (Text, Number, Boolean, Date, Enum)</li>
+            <li><code>type?: ColumnType</code> - Column type (Text, Number, Boolean, Date, DateTime, Enum)</li>
             <li><code>width?: string | number</code> - Column width</li>
           </ul>
         </Section>
@@ -264,6 +270,7 @@ function UserTable({ data }: { data: User[] }) {
       {Column.Text({ field: 'email', title: 'Email' })}
       {Column.Enum({ enum: UserRole, field: 'role', title: 'Role' })}
       {Column.Date({ field: 'lastLogin', title: 'Last Login' })}
+      {Column.DateTime({ field: 'lastUpdated', title: 'Last Updated' })}
       {Column.Boolean({ field: 'active', title: 'Status' })}
       {Column.Text({ field: 'profile.bio', title: 'Bio' })}
     </Table>

--- a/libraries/eslint-plugin/dist/index.js
+++ b/libraries/eslint-plugin/dist/index.js
@@ -294,6 +294,7 @@ export default pluginTypescript.config.apply(pluginTypescript, __spreadArray(__s
             'dot-notation': 'error',
             'eol-last': ['error', 'always'],
             'function-paren-newline': ['error', 'multiline-arguments'],
+            'jsdoc/escape-inline-tags': 'error',
             'no-console': 'error',
             'no-return-assign': 'error',
             'no-shadow': 'error',

--- a/libraries/eslint-plugin/index.ts
+++ b/libraries/eslint-plugin/index.ts
@@ -285,6 +285,7 @@ export default pluginTypescript.config(
       'dot-notation': 'error',
       'eol-last': ['error', 'always'],
       'function-paren-newline': ['error', 'multiline-arguments'],
+      'jsdoc/escape-inline-tags': 'error',
       'no-console': 'error',
       'no-return-assign': 'error',
       'no-shadow': 'error',

--- a/libraries/eslint-plugin/rules/no-mixed-type-imports.test.ts
+++ b/libraries/eslint-plugin/rules/no-mixed-type-imports.test.ts
@@ -10,11 +10,11 @@ describe('no-mixed-type-imports', () => {
       code,
       [
         {
+          files: ['**/*.ts', '**/*.tsx'],
           languageOptions: {
             parser,
             parserOptions: {
               ecmaVersion: 'latest',
-              project: './tsconfig.json',
               sourceType: 'module',
             },
           },
@@ -30,11 +30,11 @@ describe('no-mixed-type-imports', () => {
           },
         },
       ],
-      { filename: __filename, fix: true },
+      { filename: 'no-mixed-type-imports.fixture.ts', fix: true },
     )
   }
 
-  test.skipIf(!!Bun.env.CI)('outputs with/out semicolons, based on input line', () => {
+  test('outputs with/out semicolons, based on input line', () => {
     const semi = lint("import { a, type b, c } from 'module';")
     expect(semi.fixed).toBe(true)
     expect(semi.output.split(/\n/)).toEqual([

--- a/libraries/react/components/AutoComplete/AutoComplete.tsx
+++ b/libraries/react/components/AutoComplete/AutoComplete.tsx
@@ -17,9 +17,9 @@ import './AutoComplete.styles.ts'
 /** Props for the AutoComplete component. */
 interface Props<T = unknown>
   extends IAccessible, IPrefixSuffix, IPlaceholder, IFocusable, Omit<IPopup, 'arrow'> {
-  /** Whether to automatically focus the input on mount. @default false */
+  /** Whether to automatically focus the input on mount. Defaults to `false`. */
   autoFocus?: boolean,
-  /** Whether to close the dropdown when an option is selected. @default true */
+  /** Whether to close the dropdown when an option is selected. Defaults to `true`. */
   closeOnSelect?: boolean,
   /** Function to get the disabled state of an option. */
   getOptionDisabled?: (option: T) => boolean,
@@ -29,7 +29,7 @@ interface Props<T = unknown>
   getOptionLabel: (option: T) => React.ReactNode,
   /** Function to get the value for an option. */
   getOptionValue: (option: T) => string,
-  /** Minimum length of search query before triggering search. @default 0 */
+  /** Minimum length of search query before triggering search. Defaults to `0`. */
   minimumQueryLength?: number,
   /** A callback function that is called when the dropdown is closed. */
   onClose?: () => void,

--- a/libraries/react/components/CheckboxEditor/CheckboxEditor.tsx
+++ b/libraries/react/components/CheckboxEditor/CheckboxEditor.tsx
@@ -12,7 +12,7 @@ import './CheckboxEditor.styles.ts'
 
 /** Props specific to checkbox editor. */
 interface Props extends IAccessible, IFocusable {
-  /** Whether to allow indeterminate state. @default false */
+  /** Whether to allow indeterminate state. Defaults to `false`. */
   allowIndeterminate?: boolean,
   /** The children of the component. */
   children?: React.ReactNode,

--- a/libraries/react/components/Component/Component.tsx
+++ b/libraries/react/components/Component/Component.tsx
@@ -31,7 +31,7 @@ interface TProps<E extends Element = HTMLDivElement> {
 type P<E extends Element, T> = TProps<E> & T
 
 /**
- * The abstract base class for all components in the @basis/react package.
+ * The abstract base class for all components in the `@basis/react` package.
  * @template Props The props of the component.
  * @template Element The root element type of the component.
  * @template State The state of the component.

--- a/libraries/react/components/Table/Cell.test.tsx
+++ b/libraries/react/components/Table/Cell.test.tsx
@@ -96,6 +96,24 @@ describe('Cell', () => {
     expect(node).toHaveTextContent('12/1/2023')
   })
 
+  test('renders datetime as formatted string for datetime type', async () => {
+    const iso = '2023-12-01T10:00:00Z'
+    const dateRow = { ...defaultProps.row, lastLogin: iso }
+    const { node } = await render(
+      <Cell
+        {...defaultProps}
+        column={{ field: 'lastLogin' }}
+        field="lastLogin"
+        row={dateRow}
+        type={ColumnType.DateTime}
+      />,
+    )
+    expect(node).toHaveAttribute('data-field', 'lastLogin')
+    expect(node).toHaveAttribute('data-type', 'datetime')
+    const expected = new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+    expect(node).toHaveTextContent(expected)
+  })
+
   test('renders custom component when provided', async () => {
     const CustomComponent = ({ value }: { value: TestRow['user'] }) => (
       <div data-testid="custom-component">

--- a/libraries/react/components/Table/Cell.tsx
+++ b/libraries/react/components/Table/Cell.tsx
@@ -110,6 +110,13 @@ export class Cell<TRow, TField extends PathOf<TRow> = PathOf<TRow>>
           />,
         )
 
+      case ColumnType.DateTime:
+        return super.content(
+          value
+            ? new Date(value as string).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+            : '',
+        )
+
       case ColumnType.Date:
         // For now, render as text since we don't have a DateEditor
         return super.content(

--- a/libraries/react/components/Table/Column.tsx
+++ b/libraries/react/components/Table/Column.tsx
@@ -10,6 +10,7 @@ import { Component } from '../Component/Component'
 export enum ColumnType {
   Boolean = 'boolean',
   Date = 'date',
+  DateTime = 'datetime',
   Enum = 'enum',
   Number = 'number',
   Text = 'text',
@@ -69,6 +70,16 @@ export class Column<TRow, TField extends PathOf<TRow> = PathOf<TRow>>
       sortBy: SortBy.Value,
       ...declaration,
       type: ColumnType.Date,
+    }
+    return <Column<TRow, TField> {...props} />
+  }
+  static DateTime<TRow, TField extends PathOf<TRow> = PathOf<TRow>>(declaration: ColumnProps<TRow, TField>) {
+    const props = {
+      ...Column.defaultProps,
+      align: TextAlign.Center,
+      sortBy: SortBy.Value,
+      ...declaration,
+      type: ColumnType.DateTime,
     }
     return <Column<TRow, TField> {...props} />
   }

--- a/libraries/react/components/Table/HeaderCell.tsx
+++ b/libraries/react/components/Table/HeaderCell.tsx
@@ -80,6 +80,7 @@ export class HeaderCell<TRow, TField extends PathOf<TRow>>
     switch (type) {
       case ColumnType.Boolean:
       case ColumnType.Date:
+      case ColumnType.DateTime:
       case ColumnType.Number:
         return SortBy.Value
 

--- a/libraries/react/components/Table/TypedTable.ts
+++ b/libraries/react/components/Table/TypedTable.ts
@@ -7,6 +7,7 @@ interface TypedTableInterface<TRow extends object> {
   Column: {
     Boolean: (props: ColumnProps<TRow, PathOf<TRow>>) => React.ReactNode,
     Date: (props: ColumnProps<TRow, PathOf<TRow>>) => React.ReactNode,
+    DateTime: (props: ColumnProps<TRow, PathOf<TRow>>) => React.ReactNode,
     Enum: (props: ColumnProps<TRow, PathOf<TRow>>) => React.ReactNode,
     Number: (props: ColumnProps<TRow, PathOf<TRow>>) => React.ReactNode,
     Text: (props: ColumnProps<TRow, PathOf<TRow>>) => React.ReactNode,

--- a/libraries/react/components/Tag/Tag.tsx
+++ b/libraries/react/components/Tag/Tag.tsx
@@ -10,7 +10,7 @@ interface Props {
   children: React.ReactNode,
   /** Callback function called when the remove button is clicked. */
   onRemove?: (event: React.MouseEvent<HTMLAnchorElement>) => void,
-  /** Whether the tag can be removed. @default false */
+  /** Whether the tag can be removed. Defaults to `false`. */
   removable?: boolean,
 }
 

--- a/libraries/react/components/TextEditor/TextEditor.tsx
+++ b/libraries/react/components/TextEditor/TextEditor.tsx
@@ -26,7 +26,7 @@ export enum Wrap {
 interface Props extends IAccessible, IPrefixSuffix, IPlaceholder, IFocusable {
   /** Whether to enable browser autocomplete. */
   autoComplete?: boolean,
-  /** Whether to automatically focus the input on mount. @default false */
+  /** Whether to automatically focus the input on mount. Defaults to `false`. */
   autoFocus?: boolean,
   /**
    * Multiline behavior for the text editor.
@@ -35,14 +35,14 @@ interface Props extends IAccessible, IPrefixSuffix, IPlaceholder, IFocusable {
    * - `true`: Outputs a `textarea` with normal resizing and `data-multiline="true"`
    * - `'auto'`: Outputs `data-multiline="auto"` with auto-growing textarea
    * - `number`: Sets fixed number of lines, non-resizable textarea
-   * @default false
+   * Defaults to `false`.
    */
   multiline?: false | true | 'auto' | number,
   /** Callback function called when a key is pressed while the input has focus. */
   onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void,
-  /** Whether to select all text when the input receives focus. @default true */
+  /** Whether to select all text when the input receives focus. Defaults to `true`. */
   selectOnFocus?: boolean,
-  /** Whether to wrap text in the textarea (only applies when multiline is true). @default Wrap.Soft */
+  /** Whether to wrap text in the textarea (only applies when multiline is true). Defaults to `Wrap.Soft`. */
   wrap?: Wrap,
 }
 


### PR DESCRIPTION
## Summary
- Add `ColumnType.DateTime`, `Column.DateTime()`, TypedTable typing, Cell rendering (`toLocaleString` medium date + short time), and HeaderCell sort-by-value defaults
- Extend Table docs and demo data; add `AGENTS.md` (docs stay in sync with code; CI on PRs vs release on `main`)
- Add `.claude/skills/branch-and-pr.md` (convco branch/commit/PR conventions)

## Test plan
- [x] `bun test` (pre-commit hook)
- [ ] Spot-check Table docs page in the docs app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)