### PR TITLE
feat(eslint): JSDoc preset errors and branch policy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Guidance for humans and coding agents working in this repository.
 
+## Git and branches
+
+- **Do not push directly to `main`.** Create a feature branch from the latest `main` (`git checkout main && git pull && git checkout -b feat/your-topic`), commit there, and push that branch to open a pull request. Agents must not push to `main` or assume it is writable.
+
 ## Documentation
 
 - **Keep docs in the same change as the code.** Whenever you add or change public API surface, default behavior, or user-visible component behavior, update the matching documentation page under `libraries/docs/pages/` (files named `*.docs.tsx`).

--- a/libraries/eslint-plugin/dist/index.js
+++ b/libraries/eslint-plugin/dist/index.js
@@ -87,7 +87,7 @@ var plugin = function (options) {
 var IGNORE_PATHS = ['node_modules', '.cache', 'build', 'dist'];
 export default pluginTypescript.config.apply(pluginTypescript, __spreadArray(__spreadArray(__spreadArray([{ ignores: IGNORE_PATHS.flatMap(function (path) { return ["".concat(path, "/**"), "**/".concat(path, "/**")]; }) },
     eslint.configs.recommended,
-    pluginJSDoc.configs['flat/recommended-typescript']], __read(pluginTypescript.configs.strict), false), __read(pluginTypescript.configs.stylistic), false), [plugin({
+    pluginJSDoc.configs['flat/recommended-typescript-error']], __read(pluginTypescript.configs.strict), false), __read(pluginTypescript.configs.stylistic), false), [plugin({
         rules: {
             '@basis/no-mixed-type-imports': 'error',
             '@basis/no-object-padding': 'error',

--- a/libraries/eslint-plugin/index.ts
+++ b/libraries/eslint-plugin/index.ts
@@ -75,7 +75,7 @@ const IGNORE_PATHS = ['node_modules', '.cache', 'build', 'dist']
 export default pluginTypescript.config(
   { ignores: IGNORE_PATHS.flatMap(path => [`${path}/**`, `**/${path}/**`]) },
   eslint.configs.recommended,
-  pluginJSDoc.configs['flat/recommended-typescript'],
+  pluginJSDoc.configs['flat/recommended-typescript-error'],
   ...pluginTypescript.configs.strict,
   ...pluginTypescript.configs.stylistic,
   plugin({


### PR DESCRIPTION
## Summary

- Switch `@basis/eslint-plugin` to `eslint-plugin-jsdoc`'s `flat/recommended-typescript-error` so JSDoc rules from that preset are **error** severity (not warn), matching stricter documentation expectations.
- Document in `AGENTS.md` that work must land via feature branches—do not push directly to `main`.

## Notes

- Downstream repos may need JSDoc fixes when they bump basis; consumers can temporarily override specific `jsdoc/*` rules if needed.


Made with [Cursor](https://cursor.com)