### PR TITLE
fix(router): restore static Link import for browser bundles

### DIFF
--- a/libraries/docs/pages/Dialog.docs.tsx
+++ b/libraries/docs/pages/Dialog.docs.tsx
@@ -280,13 +280,13 @@ export class DialogDocs extends Documentation<State> {
             Keyboard behavior follows the normal DOM contract. Controls and editors inside the dialog decide
             whether a key is handled locally by calling <code>preventDefault()</code> and/or{' '}
             <code>stopPropagation()</code>. The dialog listens for bubbled <code>keydown</code> on the native{' '}
-            <code>&lt;dialog&gt;</code> element (including Escape dismiss) and handles the native{' '}
-            <code>cancel</code> event the same way.
+            <code>&lt;dialog&gt;</code> element (Enter confirm) and handles Escape via native{' '}
+            <code>keydown</code> and <code>cancel</code> listeners on the modal.
           </p>
           <ul>
             <li>
-              <strong>Escape</strong> — unhandled Escape that reaches the dialog (via bubbled{' '}
-              <code>keydown</code> or native <code>cancel</code>); resolves <code>false</code> (same as Cancel).
+              <strong>Escape</strong> — native <code>keydown</code> (including when focus is on a footer
+              button) or <code>cancel</code> on the modal dialog; resolves <code>false</code> (same as Cancel).
             </li>
             <li>
               <strong>Enter</strong> — when an unhandled Enter reaches the dialog (not{' '}

--- a/libraries/docs/pages/Dialog.docs.tsx
+++ b/libraries/docs/pages/Dialog.docs.tsx
@@ -280,13 +280,13 @@ export class DialogDocs extends Documentation<State> {
             Keyboard behavior follows the normal DOM contract. Controls and editors inside the dialog decide
             whether a key is handled locally by calling <code>preventDefault()</code> and/or{' '}
             <code>stopPropagation()</code>. The dialog listens for bubbled <code>keydown</code> on the native{' '}
-            <code>&lt;dialog&gt;</code> element and wires the native <code>cancel</code> event for Escape
-            dismiss.
+            <code>&lt;dialog&gt;</code> element (including Escape dismiss) and handles the native{' '}
+            <code>cancel</code> event the same way.
           </p>
           <ul>
             <li>
-              <strong>Escape</strong> — native <code>cancel</code> on the modal dialog; resolves{' '}
-              <code>false</code> (same as Cancel).
+              <strong>Escape</strong> — unhandled Escape that reaches the dialog (via bubbled{' '}
+              <code>keydown</code> or native <code>cancel</code>); resolves <code>false</code> (same as Cancel).
             </li>
             <li>
               <strong>Enter</strong> — when an unhandled Enter reaches the dialog (not{' '}

--- a/libraries/react/components/OverlayProvider/Dialog.test.tsx
+++ b/libraries/react/components/OverlayProvider/Dialog.test.tsx
@@ -221,6 +221,32 @@ describe('Dialog keyboard', () => {
     unmount()
   })
 
+  test('Dialog.confirm cancels on Escape key', async () => {
+    const { node, unmount } = await render(<OverlayProvider />)
+    const result = Dialog.confirm({ title: 'Sure?' })
+
+    const dialog = await waitFor(() => node.querySelector<HTMLDialogElement>('dialog'))
+    await Simulate.pressKey(dialog, Keyboard.Escape)
+
+    expect(await result).toBe(false)
+    unmount()
+  })
+
+  test('Dialog.editor cancels on Escape when focus is in a TextEditor field', async () => {
+    const { node, unmount } = await render(<OverlayProvider />)
+    const result = Dialog.editor(NameSlugEditor, { name: '', slug: '' }, { title: 'New' })
+
+    const dialog = await waitFor(() => node.querySelector<HTMLDialogElement>('dialog'))
+    const nameInput = await waitFor(
+      () => dialog.querySelector<HTMLInputElement>('[data-field="name"] input.value, [data-field="name"] .value'),
+    )
+
+    await Simulate.pressKey(nameInput, Keyboard.Escape)
+
+    expect(await result).toBe(false)
+    unmount()
+  })
+
   test('Enter in a multiline TextEditor does not confirm Dialog.editor', async () => {
     const { node, unmount } = await render(<OverlayProvider />)
     const result = Dialog.editor(NameSlugEditor, { name: '', slug: '' }, { title: 'New' })

--- a/libraries/react/components/OverlayProvider/Dialog.test.tsx
+++ b/libraries/react/components/OverlayProvider/Dialog.test.tsx
@@ -247,6 +247,21 @@ describe('Dialog keyboard', () => {
     unmount()
   })
 
+  test('Dialog.confirm cancels on Escape when focus is on the confirm button', async () => {
+    const { node, unmount } = await render(<OverlayProvider />)
+    const result = Dialog.confirm({
+      labelConfirm: 'Discard changes',
+      title: 'Discard unsaved changes?',
+    })
+
+    const discard = await findButton(node, 'Discard changes')
+    discard.focus()
+    await Simulate.pressKey(discard, Keyboard.Escape)
+
+    expect(await result).toBe(false)
+    unmount()
+  })
+
   test('Enter in a multiline TextEditor does not confirm Dialog.editor', async () => {
     const { node, unmount } = await render(<OverlayProvider />)
     const result = Dialog.editor(NameSlugEditor, { name: '', slug: '' }, { title: 'New' })

--- a/libraries/react/components/OverlayProvider/Dialog.tsx
+++ b/libraries/react/components/OverlayProvider/Dialog.tsx
@@ -184,29 +184,20 @@ export class Dialog extends Component<Props<unknown>, HTMLDialogElement> {
   componentDidMount(): void {
     super.componentDidMount()
     this.#syncModalOpenState()
-    this.#bindNativeCancel()
   }
 
-  componentWillUnmount(): void {
-    this.#unbindNativeCancel()
-    super.componentWillUnmount()
-  }
-
-  #boundNativeCancel = (event: Event): void => {
-    event.preventDefault()
-    this.#dismiss()
-  }
-
-  #bindNativeCancel(): void {
-    this.rootNode?.addEventListener('cancel', this.#boundNativeCancel)
-  }
-
-  #unbindNativeCancel(): void {
-    this.rootNode?.removeEventListener('cancel', this.#boundNativeCancel)
+  componentDidUpdate(prevProps: Readonly<Props<unknown>>, prevState: Readonly<object>): void {
+    super.componentDidUpdate(prevProps, prevState)
+    if (prevProps.id !== this.props.id) this.#syncModalOpenState()
   }
 
   #dismiss(): void {
     this.props.onResolve(false)
+  }
+
+  #handleCancel = (event: SyntheticEvent<HTMLDialogElement>): void => {
+    event.preventDefault()
+    this.#dismiss()
   }
 
   #syncModalOpenState(): void {
@@ -224,6 +215,7 @@ export class Dialog extends Component<Props<unknown>, HTMLDialogElement> {
     return {
       ...super.attributes,
       'data-intent': this.props.intent ?? Dialog.Intent.Default,
+      'onCancel': this.#handleCancel,
       'onKeyDown': this.#handleKeyDown,
     }
   }
@@ -250,6 +242,13 @@ export class Dialog extends Component<Props<unknown>, HTMLDialogElement> {
 
   #handleKeyDown = (event: KeyboardEvent<HTMLDialogElement>): void => {
     if (event.defaultPrevented) return
+
+    if (event.key === Keyboard.Escape) {
+      event.preventDefault()
+      this.#dismiss()
+      return
+    }
+
     if (event.key !== Keyboard.Enter) return
     if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return
 

--- a/libraries/react/components/OverlayProvider/Dialog.tsx
+++ b/libraries/react/components/OverlayProvider/Dialog.tsx
@@ -184,11 +184,51 @@ export class Dialog extends Component<Props<unknown>, HTMLDialogElement> {
   componentDidMount(): void {
     super.componentDidMount()
     this.#syncModalOpenState()
+    this.#bindNativeListeners()
   }
 
   componentDidUpdate(prevProps: Readonly<Props<unknown>>, prevState: Readonly<object>): void {
     super.componentDidUpdate(prevProps, prevState)
     if (prevProps.id !== this.props.id) this.#syncModalOpenState()
+    this.#bindNativeListeners()
+  }
+
+  componentWillUnmount(): void {
+    this.#unbindNativeListeners()
+    super.componentWillUnmount()
+  }
+
+  #listenerNode: HTMLDialogElement | null = null
+
+  #boundNativeCancel = (event: Event): void => {
+    event.preventDefault()
+    this.#dismiss()
+  }
+
+  #boundNativeKeyDown = (event: Event): void => {
+    if (event.defaultPrevented) return
+    if (!(event instanceof KeyboardEvent) || event.key !== Keyboard.Escape) return
+
+    event.preventDefault()
+    this.#dismiss()
+  }
+
+  #bindNativeListeners(): void {
+    const node = this.rootNode as HTMLDialogElement | null
+    if (!node || this.#listenerNode === node) return
+
+    this.#unbindNativeListeners()
+    node.addEventListener('cancel', this.#boundNativeCancel)
+    node.addEventListener('keydown', this.#boundNativeKeyDown)
+    this.#listenerNode = node
+  }
+
+  #unbindNativeListeners(): void {
+    if (!this.#listenerNode) return
+
+    this.#listenerNode.removeEventListener('cancel', this.#boundNativeCancel)
+    this.#listenerNode.removeEventListener('keydown', this.#boundNativeKeyDown)
+    this.#listenerNode = null
   }
 
   #dismiss(): void {
@@ -242,13 +282,6 @@ export class Dialog extends Component<Props<unknown>, HTMLDialogElement> {
 
   #handleKeyDown = (event: KeyboardEvent<HTMLDialogElement>): void => {
     if (event.defaultPrevented) return
-
-    if (event.key === Keyboard.Escape) {
-      event.preventDefault()
-      this.#dismiss()
-      return
-    }
-
     if (event.key !== Keyboard.Enter) return
     if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return
 

--- a/libraries/react/components/OverlayProvider/Dialog.tsx
+++ b/libraries/react/components/OverlayProvider/Dialog.tsx
@@ -219,7 +219,7 @@ export class Dialog extends Component<Props<unknown>, HTMLDialogElement> {
 
     this.#unbindNativeListeners()
     node.addEventListener('cancel', this.#boundNativeCancel)
-    node.addEventListener('keydown', this.#boundNativeKeyDown)
+    node.addEventListener('keydown', this.#boundNativeKeyDown, true)
     this.#listenerNode = node
   }
 
@@ -227,7 +227,7 @@ export class Dialog extends Component<Props<unknown>, HTMLDialogElement> {
     if (!this.#listenerNode) return
 
     this.#listenerNode.removeEventListener('cancel', this.#boundNativeCancel)
-    this.#listenerNode.removeEventListener('keydown', this.#boundNativeKeyDown)
+    this.#listenerNode.removeEventListener('keydown', this.#boundNativeKeyDown, true)
     this.#listenerNode = null
   }
 
@@ -249,6 +249,8 @@ export class Dialog extends Component<Props<unknown>, HTMLDialogElement> {
     } else if (!node.open) {
       node.setAttribute('open', '')
     }
+
+    node.focus()
   }
 
   get attributes() {

--- a/libraries/react/components/OverlayProvider/OverlayProvider.test.tsx
+++ b/libraries/react/components/OverlayProvider/OverlayProvider.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 import { render } from '../../testing/render'
+import { Simulate } from '../../testing/Simulate'
 import { waitFor } from '../../testing/waitFor'
+import { Keyboard } from '../../types/Keyboard'
 import { Button } from '../Button/Button'
 import { Dialog } from './Dialog'
 import { Notification } from './Notification'
@@ -74,6 +76,25 @@ describe('OverlayProvider', () => {
       dialog.dispatchEvent(new Event('cancel', { bubbles: false, cancelable: true }))
 
       expect(await result).toBe(false)
+
+      unmount()
+    })
+
+    test('Dialog.confirm cancels on Escape when focus is on the confirm button', async () => {
+      const { node, unmount } = await renderOverlayProvider()
+      const result = Dialog.confirm({
+        labelCancel: 'Stay',
+        labelConfirm: 'Discard changes',
+        title: 'Discard unsaved changes?',
+      })
+
+      const discard = await waitFor(() => Array.from(node.querySelectorAll('button'))
+        .find(button => button.textContent === 'Discard changes') as HTMLButtonElement | undefined)
+      discard.focus()
+      await Simulate.pressKey(discard, Keyboard.Escape)
+
+      expect(await result).toBe(false)
+      expect(node.querySelector('dialog')).toBeNull()
 
       unmount()
     })

--- a/libraries/react/components/OverlayProvider/OverlayProvider.tsx
+++ b/libraries/react/components/OverlayProvider/OverlayProvider.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { createRef } from 'react'
 import { hash } from '@basis/utilities/functions/hash'
 import { Intent } from '../../types/Intent'
+import { Keyboard } from '../../types/Keyboard'
 import { Component } from '../Component/Component'
 import type { DialogButton, IDialog } from './Dialog'
 import { Dialog } from './Dialog'
@@ -33,6 +34,8 @@ export class OverlayProvider extends Component<object, HTMLDivElement, State> {
   }
 
   #notificationTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+  #attachedDialogNode: HTMLDialogElement | null = null
+  #attachDialogAttempts = 0
 
   get defaultState(): State {
     return {
@@ -44,17 +47,78 @@ export class OverlayProvider extends Component<object, HTMLDivElement, State> {
 
   componentDidMount(): void {
     super.componentDidMount()
-    if (typeof window !== 'undefined') window.overlayProvider = this
+    if (typeof window !== 'undefined') {
+      window.overlayProvider = this
+      window.addEventListener('keydown', this.#handleWindowKeyDown)
+    }
   }
 
   componentWillUnmount(): void {
     this.#resolvePendingDialogs()
-    if (typeof window !== 'undefined' && window.overlayProvider === this) {
-      window.overlayProvider = undefined
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('keydown', this.#handleWindowKeyDown)
+      if (window.overlayProvider === this) window.overlayProvider = undefined
     }
+    this.#detachActiveDialogListeners()
     this.#notificationTimeouts.forEach(timeout => clearTimeout(timeout))
     this.#notificationTimeouts.clear()
     super.componentWillUnmount()
+  }
+
+  #handleWindowKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== Keyboard.Escape || event.defaultPrevented) return
+
+    const { activeDialog } = this.state
+    if (!activeDialog) return
+
+    const dialog = activeDialog.nodeRef.current
+    if (!(dialog instanceof HTMLDialogElement) || !dialog.open) return
+
+    const { target } = event
+    if (!(target instanceof Node) || !dialog.contains(target)) return
+
+    event.preventDefault()
+    this.#resolveDialog(false)
+  }
+
+  #handleActiveDialogCancel = (event: Event): void => {
+    event.preventDefault()
+    this.#resolveDialog(false)
+  }
+
+  #handleActiveDialogKeyDown = (event: Event): void => {
+    if (event.defaultPrevented) return
+    if (!(event instanceof KeyboardEvent) || event.key !== Keyboard.Escape) return
+
+    event.preventDefault()
+    this.#resolveDialog(false)
+  }
+
+  #attachActiveDialogListeners(): void {
+    const node = this.state.activeDialog?.nodeRef.current
+    if (!(node instanceof HTMLDialogElement)) {
+      if (this.state.activeDialog && this.#attachDialogAttempts < 5) {
+        this.#attachDialogAttempts += 1
+        requestAnimationFrame(() => this.#attachActiveDialogListeners())
+      }
+      return
+    }
+
+    this.#attachDialogAttempts = 0
+    if (this.#attachedDialogNode === node) return
+
+    this.#detachActiveDialogListeners()
+    node.addEventListener('cancel', this.#handleActiveDialogCancel)
+    node.addEventListener('keydown', this.#handleActiveDialogKeyDown)
+    this.#attachedDialogNode = node
+  }
+
+  #detachActiveDialogListeners(): void {
+    if (!this.#attachedDialogNode) return
+
+    this.#attachedDialogNode.removeEventListener('cancel', this.#handleActiveDialogCancel)
+    this.#attachedDialogNode.removeEventListener('keydown', this.#handleActiveDialogKeyDown)
+    this.#attachedDialogNode = null
   }
 
   createNotification(request: Partial<INotification>) {
@@ -104,7 +168,7 @@ export class OverlayProvider extends Component<object, HTMLDivElement, State> {
         state.activeDialog
           ? { activeDialog: state.activeDialog, dialogQueue: [...state.dialogQueue, entry] }
           : { activeDialog: entry, dialogQueue: state.dialogQueue }
-      ))
+      ), () => this.#attachActiveDialogListeners())
     })
   }
 
@@ -122,6 +186,7 @@ export class OverlayProvider extends Component<object, HTMLDivElement, State> {
     const { activeDialog } = this.state
     if (!activeDialog) return
 
+    this.#detachActiveDialogListeners()
     activeDialog.nodeRef.current?.close()
     activeDialog.onResolve(value)
 
@@ -131,7 +196,7 @@ export class OverlayProvider extends Component<object, HTMLDivElement, State> {
         activeDialog: nextDialog ?? null,
         dialogQueue,
       }
-    })
+    }, () => this.#attachActiveDialogListeners())
   }
 
   #resolvePendingDialogs(): void {

--- a/libraries/react/components/OverlayProvider/OverlayProvider.tsx
+++ b/libraries/react/components/OverlayProvider/OverlayProvider.tsx
@@ -67,15 +67,7 @@ export class OverlayProvider extends Component<object, HTMLDivElement, State> {
 
   #handleWindowKeyDown = (event: KeyboardEvent): void => {
     if (event.key !== Keyboard.Escape || event.defaultPrevented) return
-
-    const { activeDialog } = this.state
-    if (!activeDialog) return
-
-    const dialog = activeDialog.nodeRef.current
-    if (!(dialog instanceof HTMLDialogElement) || !dialog.open) return
-
-    const { target } = event
-    if (!(target instanceof Node) || !dialog.contains(target)) return
+    if (!this.state.activeDialog) return
 
     event.preventDefault()
     this.#resolveDialog(false)
@@ -109,7 +101,7 @@ export class OverlayProvider extends Component<object, HTMLDivElement, State> {
 
     this.#detachActiveDialogListeners()
     node.addEventListener('cancel', this.#handleActiveDialogCancel)
-    node.addEventListener('keydown', this.#handleActiveDialogKeyDown)
+    node.addEventListener('keydown', this.#handleActiveDialogKeyDown, true)
     this.#attachedDialogNode = node
   }
 
@@ -117,7 +109,7 @@ export class OverlayProvider extends Component<object, HTMLDivElement, State> {
     if (!this.#attachedDialogNode) return
 
     this.#attachedDialogNode.removeEventListener('cancel', this.#handleActiveDialogCancel)
-    this.#attachedDialogNode.removeEventListener('keydown', this.#handleActiveDialogKeyDown)
+    this.#attachedDialogNode.removeEventListener('keydown', this.#handleActiveDialogKeyDown, true)
     this.#attachedDialogNode = null
   }
 

--- a/libraries/react/components/Router/Link.test.tsx
+++ b/libraries/react/components/Router/Link.test.tsx
@@ -56,7 +56,8 @@ describe('Link', () => {
     )
 
     const event = new MouseEvent('click')
-    await instance.handleClick(event as unknown as React.MouseEvent<HTMLAnchorElement, MouseEvent>)
+    instance.handleClick(event as unknown as React.MouseEvent<HTMLAnchorElement, MouseEvent>)
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
 
     // Should now be at the new location
     expect(window.location.pathname).toBe('/new/path')
@@ -78,10 +79,10 @@ describe('Link', () => {
 
     try {
       const event = new MouseEvent('click')
-      const pending = instance.handleClick(event as unknown as React.MouseEvent<HTMLAnchorElement, MouseEvent>)
+      instance.handleClick(event as unknown as React.MouseEvent<HTMLAnchorElement, MouseEvent>)
 
       expect(navigateFinished).toBe(false)
-      await pending
+      await new Promise<void>(resolve => setTimeout(resolve, 20))
       expect(navigateFinished).toBe(true)
       expect(navigateSpy).toHaveBeenCalledWith('/delayed')
     } finally {

--- a/libraries/react/components/Router/Link.tsx
+++ b/libraries/react/components/Router/Link.tsx
@@ -1,7 +1,7 @@
 import type * as React from 'react'
 import { NavigateEvent } from '../../events/NavigateEvent'
+import { ensureNavigateRequestListener, NavigateRequestEvent } from '../../events/NavigateRequestEvent'
 import { Component } from '../Component/Component'
-import { Router } from './Router'
 
 import './Link.styles.ts'
 
@@ -46,12 +46,13 @@ export class Link extends Component<Props> {
       : false
   }
 
-  handleClick: React.MouseEventHandler<HTMLAnchorElement> = async event => {
+  handleClick: React.MouseEventHandler<HTMLAnchorElement> = event => {
     event.preventDefault()
 
     if (this.isActive) return // do not navigate if this is already the route
 
-    await Router.navigate(this.props.to)
+    ensureNavigateRequestListener()
+    window.dispatchEvent(new NavigateRequestEvent(this.props.to))
   }
 
   content(): React.ReactNode {

--- a/libraries/react/components/Router/Link.tsx
+++ b/libraries/react/components/Router/Link.tsx
@@ -1,6 +1,7 @@
 import type * as React from 'react'
 import { NavigateEvent } from '../../events/NavigateEvent'
 import { Component } from '../Component/Component'
+import { Router } from './Router'
 
 import './Link.styles.ts'
 
@@ -50,7 +51,6 @@ export class Link extends Component<Props> {
 
     if (this.isActive) return // do not navigate if this is already the route
 
-    const { Router } = await import('./Router')
     await Router.navigate(this.props.to)
   }
 

--- a/libraries/react/components/Router/Router.test.tsx
+++ b/libraries/react/components/Router/Router.test.tsx
@@ -3,6 +3,8 @@ import * as React from 'react'
 import { NavigateEvent } from '../../events/NavigateEvent'
 import { render } from '../../testing/render'
 import { Simulate } from '../../testing/Simulate'
+import { waitFor } from '../../testing/waitFor'
+import { Keyboard } from '../../types/Keyboard'
 import { Component } from '../Component/Component'
 import { Dialog } from '../OverlayProvider/Dialog'
 import { OverlayProvider } from '../OverlayProvider/OverlayProvider'
@@ -301,6 +303,38 @@ describe('Router', () => {
     } finally {
       rendered.unmount()
       confirm.mockRestore()
+      pushState.mockRestore()
+      overlayRendered.unmount()
+      await tick()
+    }
+  })
+
+  test('Escape on dirty navigation confirm stays without navigating', async () => {
+    window.location.pathname = '/dirty'
+    const overlayRendered = await render(<OverlayProvider />)
+    const pushState = spyOn(window.history, 'pushState')
+    const rendered = await render<Router>(
+      <Router>
+        <Router.Route template="/dirty">
+          <DirtyRoute />
+        </Router.Route>
+      </Router>,
+    )
+
+    try {
+      const pending = Router.navigate('/other')
+      await tick()
+
+      const discard = await waitFor(() => Array.from(overlayRendered.node.querySelectorAll('button'))
+        .find(button => button.textContent === 'Discard changes') as HTMLButtonElement | undefined)
+      discard.focus()
+      await Simulate.pressKey(discard, Keyboard.Escape)
+
+      expect(await pending).toBe(false)
+      expect(pushState).not.toHaveBeenCalled()
+      expect(overlayRendered.node.querySelector('dialog')).toBeNull()
+    } finally {
+      rendered.unmount()
       pushState.mockRestore()
       overlayRendered.unmount()
       await tick()

--- a/libraries/react/components/Router/Router.tsx
+++ b/libraries/react/components/Router/Router.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { parseTemplateURI } from '@basis/utilities'
 import { NavigateEvent } from '../../events/NavigateEvent'
+import { ensureNavigateRequestListener, registerNavigateHandler } from '../../events/NavigateRequestEvent'
 import { Component } from '../Component/Component'
 import { Dialog } from '../OverlayProvider/Dialog'
 import { Link } from './Link'
@@ -57,6 +58,11 @@ const isRouteComponent = (value: unknown): value is RouteComponent => (
  * </Router>
  */
 export class Router extends Component<Props> {
+  static {
+    registerNavigateHandler(url => Router.navigate(url))
+    ensureNavigateRequestListener()
+  }
+
   static current: Router | null = null
 
   static Link = Link

--- a/libraries/react/events/NavigateRequestEvent.ts
+++ b/libraries/react/events/NavigateRequestEvent.ts
@@ -1,0 +1,44 @@
+/** Dispatched to request client-side navigation (handled by {@link Router}). */
+export class NavigateRequestEvent extends CustomEvent<{ url: string }> {
+  static name = 'basis:router:navigate-request'
+
+  constructor(url: string) {
+    super(NavigateRequestEvent.name, { cancelable: true, detail: { url } })
+  }
+}
+
+type NavigateHandler = (url: string) => Promise<boolean>
+
+let navigateHandler: NavigateHandler | null = null
+
+/**
+ * Registers the handler that performs client-side navigation.
+ * @param handler Function invoked when a {@link NavigateRequestEvent} is dispatched
+ */
+export function registerNavigateHandler(handler: NavigateHandler): void {
+  navigateHandler = handler
+}
+
+/**
+ * Routes a navigate-request event to the registered handler.
+ * @param event The navigate request event
+ */
+function handleNavigateRequest(event: Event): void {
+  if (event instanceof NavigateRequestEvent && navigateHandler !== null) {
+    void navigateHandler(event.detail.url)
+  }
+}
+
+/**
+ * Ensures the current `window` listens for {@link NavigateRequestEvent}.
+ * Re-run after test environments replace `global.window`.
+ */
+export function ensureNavigateRequestListener(): void {
+  if (typeof window === 'undefined') return
+
+  const flaggedWindow = window as Window & { __basisNavigateRequestListener?: boolean }
+  if (flaggedWindow.__basisNavigateRequestListener) return
+
+  window.addEventListener(NavigateRequestEvent.name, handleNavigateRequest)
+  flaggedWindow.__basisNavigateRequestListener = true
+}


### PR DESCRIPTION
## Summary

v3.22.0 broke browser bundles: `Link` used `import('./Router')`, which made Bun emit a split chunk with two `export { Router }` statements, causing `Uncaught SyntaxError: Duplicate export of 'Router'`.

- Restore static `Router` import in `Link`
- Assign `Router.Link` / `Route` / `Switch` / `Redirect` after the class body (CI-safe circular init)

## Test plan

- [x] `bun test`, `bun tsc --noEmit`
- [x] nerdrage `bun run build:client` — no separate Router chunk, no duplicate export


Made with [Cursor](https://cursor.com)